### PR TITLE
refactor(localpv): rename provisioner from local to lvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ metadata:
 parameters:
   storage: "lvm"
   volgroup: "lvmpv-vg"
-provisioner: local.csi.openebs.io
+provisioner: lvm.csi.openebs.io
 ```
 
 ##### VolumeGroup Availability
@@ -89,7 +89,7 @@ allowVolumeExpansion: true
 parameters:
   storage: "lvm"
   volgroup: "lvmpv-vg"
-provisioner: local.csi.openebs.io
+provisioner: lvm.csi.openebs.io
 allowedTopologies:
 - matchLabelExpressions:
   - key: kubernetes.io/hostname
@@ -100,7 +100,7 @@ allowedTopologies:
 
 The above storage class tells that volume group "lvmpv-vg" is available on nodes lvmpv-node1 and lvmpv-node2 only. The LVM driver will create volumes on those nodes only.
 
-Please note that the provisioner name for LVM driver is "local.csi.openebs.io", we have to use this while creating the storage class so that the volume provisioning/deprovisioning request can come to LVM driver.
+Please note that the provisioner name for LVM driver is "lvm.csi.openebs.io", we have to use this while creating the storage class so that the volume provisioning/deprovisioning request can come to LVM driver.
 
 #### 2. Create the PVC
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,14 +19,15 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
+	"os"
+
 	config "github.com/openebs/lvm-localpv/pkg/config"
 	"github.com/openebs/lvm-localpv/pkg/driver"
 	"github.com/openebs/lvm-localpv/pkg/lvm"
 	"github.com/openebs/lvm-localpv/pkg/version"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
-	"log"
-	"os"
 )
 
 /*
@@ -66,7 +67,7 @@ func main() {
 	)
 
 	cmd.PersistentFlags().StringVar(
-		&config.DriverName, "name", "local.csi.openebs.io", "Name of this driver",
+		&config.DriverName, "name", "lvm.csi.openebs.io", "Name of this driver",
 	)
 
 	cmd.PersistentFlags().StringVar(

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -378,7 +378,7 @@ status:
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
-  name: local.csi.openebs.io
+  name: lvm.csi.openebs.io
 spec:
   # do not require volumeattachment
   attachRequired: false

--- a/deploy/sample/fio-block.yaml
+++ b/deploy/sample/fio-block.yaml
@@ -5,7 +5,7 @@ metadata:
 allowVolumeExpansion: true
 parameters:
   volgroup: "lvmvg"
-provisioner: local.csi.openebs.io
+provisioner: lvm.csi.openebs.io
 #allowedTopologies:
 #- matchLabelExpressions:
 #  - key: kubernetes.io/hostname

--- a/deploy/sample/fio.yaml
+++ b/deploy/sample/fio.yaml
@@ -5,7 +5,7 @@ metadata:
 allowVolumeExpansion: true
 parameters:
   volgroup: "lvmvg"
-provisioner: local.csi.openebs.io
+provisioner: lvm.csi.openebs.io
 #allowedTopologies:
 #- matchLabelExpressions:
 #  - key: kubernetes.io/hostname

--- a/deploy/sample/lvmsnapclass.yaml
+++ b/deploy/sample/lvmsnapclass.yaml
@@ -4,5 +4,5 @@ metadata:
   name: lvmpv-snapclass
   annotations:
     snapshot.storage.kubernetes.io/is-default-class: "true"
-driver: local.csi.openebs.io
+driver: lvm.csi.openebs.io
 deletionPolicy: Delete

--- a/deploy/yamls/lvm-driver.yaml
+++ b/deploy/yamls/lvm-driver.yaml
@@ -5,7 +5,7 @@
 apiVersion: storage.k8s.io/v1beta1
 kind: CSIDriver
 metadata:
-  name: local.csi.openebs.io
+  name: lvm.csi.openebs.io
 spec:
   # do not require volumeattachment
   attachRequired: false

--- a/docs/raw-block-volume.md
+++ b/docs/raw-block-volume.md
@@ -12,7 +12,7 @@ metadata:
   allowVolumeExpansion: true
   parameters:
     volgroup: "lvmpv-vg"
-    provisioner: local.csi.openebs.io
+    provisioner: lvm.csi.openebs.io
 ```
 
 Now we can create a pvc with volumeMode as Block to request for a Raw Block Volume :-

--- a/docs/resize.md
+++ b/docs/resize.md
@@ -17,7 +17,7 @@ allowVolumeExpansion: true
 parameters:
   fstype: "ext4"
   volgroup: "lvmpv-vg"
-provisioner: local.csi.openebs.io
+provisioner: lvm.csi.openebs.io
 
 
 $ kubectl apply -f sc.yaml

--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -14,7 +14,7 @@ metadata:
   name: lvmpv-snapclass
   annotations:
     snapshot.storage.kubernetes.io/is-default-class: "true"
-driver: local.csi.openebs.io
+driver: lvm.csi.openebs.io
 deletionPolicy: Delete
 ```
 

--- a/e2e-tests/experiments/functional/lvm-volume-resize/README.md
+++ b/e2e-tests/experiments/functional/lvm-volume-resize/README.md
@@ -11,7 +11,7 @@ metadata:
 allowVolumeExpansion: true
 parameters:
   volgroup: "lvmvg"
-provisioner: local.csi.openebs.io
+provisioner: lvm.csi.openebs.io
 ```
 
 ## Supported platforms:

--- a/e2e-tests/experiments/lvm-localpv-provisioner/openebs-lvmsc.j2
+++ b/e2e-tests/experiments/lvm-localpv-provisioner/openebs-lvmsc.j2
@@ -6,7 +6,7 @@ metadata:
 allowVolumeExpansion: true
 parameters:
   volgroup: "{{ vg_name }}"
-provisioner: local.csi.openebs.io
+provisioner: lvm.csi.openebs.io
 
 ---
 apiVersion: storage.k8s.io/v1
@@ -17,4 +17,4 @@ allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 parameters:
   volgroup: "{{ vg_name }}"
-provisioner: local.csi.openebs.io
+provisioner: lvm.csi.openebs.io

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -49,7 +49,7 @@ var (
 	PodClient        *pod.KubeClient
 	nsName           = "lvm"
 	scName           = "lvmpv-sc"
-	LocalProvisioner = "local.csi.openebs.io"
+	LocalProvisioner = "lvm.csi.openebs.io"
 	pvcName          = "lvmpv-pvc"
 	snapName         = "lvmpv-snap"
 	appName          = "busybox-lvmpv"


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Eventually we can merge all three plugins under single one. But till then we can keep it consistent across sister repositories (zfs & device).

**What this PR does?**:
Replace `local.csi.openebs.io` to `lvm.csi.openebs.io`.

**Does this PR require any upgrade changes?**:
NA

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
