### PR TITLE
chore(k8s): updated storage and apiextension version to v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ bootstrap: controller-gen
 
 .PHONY: controller-gen
 controller-gen:
-	TMP_DIR=$(shell mktemp -d) && cd $$TMP_DIR && go mod init tmp && go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.2.8 && rm -rf $$TMP_DIR;
+	TMP_DIR=$(shell mktemp -d) && cd $$TMP_DIR && go mod init tmp && go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 && rm -rf $$TMP_DIR;
 
 # SRC_PKG is the path of code files
 SRC_PKG := github.com/openebs/lvm-localpv/pkg

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -32,35 +32,14 @@ metadata:
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: lvmvolumes.local.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.volGroup
-    description: volume group where the volume is created
-    name: VolGroup
-    type: string
-  - JSONPath: .spec.ownerNodeID
-    description: Node where the volume is created
-    name: Node
-    type: string
-  - JSONPath: .spec.capacity
-    description: Size of the volume
-    name: Size
-    type: string
-  - JSONPath: .status.state
-    description: Status of the volume
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of the volume
-    name: Age
-    type: date
   group: local.openebs.io
   names:
     kind: LVMVolume
@@ -69,92 +48,111 @@ spec:
     shortNames:
     - lvmvol
     singular: lvmvolume
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: LVMVolume represents a LVM based volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines LVM info
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the volume group is present
-                which is where the volume has been provisioned. OwnerNodeID can not
-                be edited after the volume has been provisioned.
-              minLength: 1
-              type: string
-            shared:
-              description: Shared specifies whether the volume can be shared among
-                multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
-                will not allow the volumes to be mounted by more than one pods.
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volGroup:
-              description: VolGroup specifies the name of the volume group where the
-                volume has been created.
-              minLength: 1
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - volGroup
-          type: object
-        status:
-          description: VolStatus string that specifies the current state of the volume
-            provisioning request.
-          properties:
-            error:
-              description: Error denotes the error occurred during provisioning/expanding
-                a volume. Error field should only be set when State becomes Failed.
-              properties:
-                code:
-                  description: VolumeErrorCode represents the error code to represent
-                    specific class of errors.
-                  type: string
-                message:
-                  type: string
-              type: object
-            state:
-              description: State specifies the current state of the volume provisioning
-                request. The state "Pending" means that the volume creation request
-                has not processed yet. The state "Ready" means that the volume has
-                been created and it is ready for the use. "Failed" means that volume
-                provisioning has been failed and will not be retried by node agent
-                controller.
-              enum:
-              - Pending
-              - Ready
-              - Failed
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: volume group where the volume is created
+      jsonPath: .spec.volGroup
+      name: VolGroup
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LVMVolume represents a LVM based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines LVM info
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the volume group is
+                  present which is where the volume has been provisioned. OwnerNodeID
+                  can not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volGroup:
+                description: VolGroup specifies the name of the volume group where
+                  the volume has been created.
+                minLength: 1
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - volGroup
+            type: object
+          status:
+            description: VolStatus string that specifies the current state of the
+              volume provisioning request.
+            properties:
+              error:
+                description: Error denotes the error occurred during provisioning/expanding
+                  a volume. Error field should only be set when State becomes Failed.
+                properties:
+                  code:
+                    description: VolumeErrorCode represents the error code to represent
+                      specific class of errors.
+                    type: string
+                  message:
+                    type: string
+                type: object
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use. "Failed" means that volume
+                  provisioning has been failed and will not be retried by node agent
+                  controller.
+                enum:
+                - Pending
+                - Ready
+                - Failed
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""
@@ -174,11 +172,11 @@ status:
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: lvmsnapshots.local.openebs.io
 spec:
@@ -188,69 +186,67 @@ spec:
     listKind: LVMSnapshotList
     plural: lvmsnapshots
     singular: lvmsnapshot
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: LVMSnapshot represents an LVM Snapshot of the lvm volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines LVM info
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the volume group is present
-                which is where the volume has been provisioned. OwnerNodeID can not
-                be edited after the volume has been provisioned.
-              minLength: 1
-              type: string
-            shared:
-              description: Shared specifies whether the volume can be shared among
-                multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
-                will not allow the volumes to be mounted by more than one pods.
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volGroup:
-              description: VolGroup specifies the name of the volume group where the
-                volume has been created.
-              minLength: 1
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - volGroup
-          type: object
-        status:
-          description: SnapStatus string that reflects if the snapshot was created
-            successfully
-          properties:
-            state:
-              type: string
-          type: object
-      required:
-      - spec
-      - status
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LVMSnapshot represents an LVM Snapshot of the lvm volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines LVM info
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the volume group is
+                  present which is where the volume has been provisioned. OwnerNodeID
+                  can not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volGroup:
+                description: VolGroup specifies the name of the volume group where
+                  the volume has been created.
+                minLength: 1
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - volGroup
+            type: object
+          status:
+            description: SnapStatus string that reflects if the snapshot was created
+              successfully
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
 status:
@@ -272,11 +268,11 @@ status:
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: lvmnodes.local.openebs.io
 spec:
@@ -288,81 +284,79 @@ spec:
     shortNames:
     - lvmnode
     singular: lvmnode
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: LVMNode records information about all lvm volume groups available
-        in a node. In general, the openebs node-agent creates the LVMNode object &
-        periodically synchronizing the volume groups available in the node. LVMNode
-        has an owner reference pointing to the corresponding node object.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        volumeGroups:
-          items:
-            description: VolumeGroup specifies attributes of a given vg exists on
-              node.
-            properties:
-              free:
-                anyOf:
-                - type: integer
-                - type: string
-                description: Free specifies the available capacity of volume group.
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              lvCount:
-                description: LVCount denotes total number of logical volumes in volume
-                  group.
-                format: int32
-                minimum: 0
-                type: integer
-              name:
-                description: Name of the lvm volume group.
-                minLength: 1
-                type: string
-              pvCount:
-                description: PVCount denotes total number of physical volumes constituting
-                  the volume group.
-                format: int32
-                minimum: 0
-                type: integer
-              size:
-                anyOf:
-                - type: integer
-                - type: string
-                description: Size specifies the total size of volume group.
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              uuid:
-                description: UUID denotes a unique identity of a lvm volume group.
-                minLength: 1
-                type: string
-            required:
-            - free
-            - lvCount
-            - name
-            - pvCount
-            - size
-            - uuid
-            type: object
-          type: array
-      required:
-      - volumeGroups
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LVMNode records information about all lvm volume groups available
+          in a node. In general, the openebs node-agent creates the LVMNode object
+          & periodically synchronizing the volume groups available in the node. LVMNode
+          has an owner reference pointing to the corresponding node object.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          volumeGroups:
+            items:
+              description: VolumeGroup specifies attributes of a given vg exists on
+                node.
+              properties:
+                free:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Free specifies the available capacity of volume group.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                lvCount:
+                  description: LVCount denotes total number of logical volumes in
+                    volume group.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                name:
+                  description: Name of the lvm volume group.
+                  minLength: 1
+                  type: string
+                pvCount:
+                  description: PVCount denotes total number of physical volumes constituting
+                    the volume group.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                size:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Size specifies the total size of volume group.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                uuid:
+                  description: UUID denotes a unique identity of a lvm volume group.
+                  minLength: 1
+                  type: string
+              required:
+              - free
+              - lvCount
+              - name
+              - pvCount
+              - size
+              - uuid
+              type: object
+            type: array
+        required:
+        - volumeGroups
+        type: object
     served: true
     storage: true
 status:
@@ -375,7 +369,7 @@ status:
 ---
 
 # Create the CSI Driver object
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: local.csi.openebs.io

--- a/deploy/yamls/lvm-driver.yaml
+++ b/deploy/yamls/lvm-driver.yaml
@@ -2,7 +2,7 @@
 ---
 
 # Create the CSI Driver object
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: local.csi.openebs.io

--- a/deploy/yamls/lvmnode-crd.yaml
+++ b/deploy/yamls/lvmnode-crd.yaml
@@ -11,11 +11,11 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: lvmnodes.local.openebs.io
 spec:
@@ -27,81 +27,79 @@ spec:
     shortNames:
     - lvmnode
     singular: lvmnode
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: LVMNode records information about all lvm volume groups available
-        in a node. In general, the openebs node-agent creates the LVMNode object &
-        periodically synchronizing the volume groups available in the node. LVMNode
-        has an owner reference pointing to the corresponding node object.
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        volumeGroups:
-          items:
-            description: VolumeGroup specifies attributes of a given vg exists on
-              node.
-            properties:
-              free:
-                anyOf:
-                - type: integer
-                - type: string
-                description: Free specifies the available capacity of volume group.
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              lvCount:
-                description: LVCount denotes total number of logical volumes in volume
-                  group.
-                format: int32
-                minimum: 0
-                type: integer
-              name:
-                description: Name of the lvm volume group.
-                minLength: 1
-                type: string
-              pvCount:
-                description: PVCount denotes total number of physical volumes constituting
-                  the volume group.
-                format: int32
-                minimum: 0
-                type: integer
-              size:
-                anyOf:
-                - type: integer
-                - type: string
-                description: Size specifies the total size of volume group.
-                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                x-kubernetes-int-or-string: true
-              uuid:
-                description: UUID denotes a unique identity of a lvm volume group.
-                minLength: 1
-                type: string
-            required:
-            - free
-            - lvCount
-            - name
-            - pvCount
-            - size
-            - uuid
-            type: object
-          type: array
-      required:
-      - volumeGroups
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LVMNode records information about all lvm volume groups available
+          in a node. In general, the openebs node-agent creates the LVMNode object
+          & periodically synchronizing the volume groups available in the node. LVMNode
+          has an owner reference pointing to the corresponding node object.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          volumeGroups:
+            items:
+              description: VolumeGroup specifies attributes of a given vg exists on
+                node.
+              properties:
+                free:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Free specifies the available capacity of volume group.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                lvCount:
+                  description: LVCount denotes total number of logical volumes in
+                    volume group.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                name:
+                  description: Name of the lvm volume group.
+                  minLength: 1
+                  type: string
+                pvCount:
+                  description: PVCount denotes total number of physical volumes constituting
+                    the volume group.
+                  format: int32
+                  minimum: 0
+                  type: integer
+                size:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  description: Size specifies the total size of volume group.
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                uuid:
+                  description: UUID denotes a unique identity of a lvm volume group.
+                  minLength: 1
+                  type: string
+              required:
+              - free
+              - lvCount
+              - name
+              - pvCount
+              - size
+              - uuid
+              type: object
+            type: array
+        required:
+        - volumeGroups
+        type: object
     served: true
     storage: true
 status:

--- a/deploy/yamls/lvmsnapshot-crd.yaml
+++ b/deploy/yamls/lvmsnapshot-crd.yaml
@@ -11,11 +11,11 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: lvmsnapshots.local.openebs.io
 spec:
@@ -25,69 +25,67 @@ spec:
     listKind: LVMSnapshotList
     plural: lvmsnapshots
     singular: lvmsnapshot
-  preserveUnknownFields: false
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      description: LVMSnapshot represents an LVM Snapshot of the lvm volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines LVM info
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the volume group is present
-                which is where the volume has been provisioned. OwnerNodeID can not
-                be edited after the volume has been provisioned.
-              minLength: 1
-              type: string
-            shared:
-              description: Shared specifies whether the volume can be shared among
-                multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
-                will not allow the volumes to be mounted by more than one pods.
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volGroup:
-              description: VolGroup specifies the name of the volume group where the
-                volume has been created.
-              minLength: 1
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - volGroup
-          type: object
-        status:
-          description: SnapStatus string that reflects if the snapshot was created
-            successfully
-          properties:
-            state:
-              type: string
-          type: object
-      required:
-      - spec
-      - status
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LVMSnapshot represents an LVM Snapshot of the lvm volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines LVM info
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the volume group is
+                  present which is where the volume has been provisioned. OwnerNodeID
+                  can not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volGroup:
+                description: VolGroup specifies the name of the volume group where
+                  the volume has been created.
+                minLength: 1
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - volGroup
+            type: object
+          status:
+            description: SnapStatus string that reflects if the snapshot was created
+              successfully
+            properties:
+              state:
+                type: string
+            type: object
+        required:
+        - spec
+        - status
+        type: object
     served: true
     storage: true
 status:

--- a/deploy/yamls/lvmvolume-crd.yaml
+++ b/deploy/yamls/lvmvolume-crd.yaml
@@ -11,35 +11,14 @@
 # to generate the CRD definition
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.2.8
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: lvmvolumes.local.openebs.io
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.volGroup
-    description: volume group where the volume is created
-    name: VolGroup
-    type: string
-  - JSONPath: .spec.ownerNodeID
-    description: Node where the volume is created
-    name: Node
-    type: string
-  - JSONPath: .spec.capacity
-    description: Size of the volume
-    name: Size
-    type: string
-  - JSONPath: .status.state
-    description: Status of the volume
-    name: Status
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: Age of the volume
-    name: Age
-    type: date
   group: local.openebs.io
   names:
     kind: LVMVolume
@@ -48,92 +27,111 @@ spec:
     shortNames:
     - lvmvol
     singular: lvmvolume
-  preserveUnknownFields: false
   scope: Namespaced
-  subresources: {}
-  validation:
-    openAPIV3Schema:
-      description: LVMVolume represents a LVM based volume
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: VolumeInfo defines LVM info
-          properties:
-            capacity:
-              description: Capacity of the volume
-              minLength: 1
-              type: string
-            ownerNodeID:
-              description: OwnerNodeID is the Node ID where the volume group is present
-                which is where the volume has been provisioned. OwnerNodeID can not
-                be edited after the volume has been provisioned.
-              minLength: 1
-              type: string
-            shared:
-              description: Shared specifies whether the volume can be shared among
-                multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
-                will not allow the volumes to be mounted by more than one pods.
-              enum:
-              - "yes"
-              - "no"
-              type: string
-            volGroup:
-              description: VolGroup specifies the name of the volume group where the
-                volume has been created.
-              minLength: 1
-              type: string
-          required:
-          - capacity
-          - ownerNodeID
-          - volGroup
-          type: object
-        status:
-          description: VolStatus string that specifies the current state of the volume
-            provisioning request.
-          properties:
-            error:
-              description: Error denotes the error occurred during provisioning/expanding
-                a volume. Error field should only be set when State becomes Failed.
-              properties:
-                code:
-                  description: VolumeErrorCode represents the error code to represent
-                    specific class of errors.
-                  type: string
-                message:
-                  type: string
-              type: object
-            state:
-              description: State specifies the current state of the volume provisioning
-                request. The state "Pending" means that the volume creation request
-                has not processed yet. The state "Ready" means that the volume has
-                been created and it is ready for the use. "Failed" means that volume
-                provisioning has been failed and will not be retried by node agent
-                controller.
-              enum:
-              - Pending
-              - Ready
-              - Failed
-              type: string
-          type: object
-      required:
-      - spec
-      type: object
-  version: v1alpha1
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - description: volume group where the volume is created
+      jsonPath: .spec.volGroup
+      name: VolGroup
+      type: string
+    - description: Node where the volume is created
+      jsonPath: .spec.ownerNodeID
+      name: Node
+      type: string
+    - description: Size of the volume
+      jsonPath: .spec.capacity
+      name: Size
+      type: string
+    - description: Status of the volume
+      jsonPath: .status.state
+      name: Status
+      type: string
+    - description: Age of the volume
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: LVMVolume represents a LVM based volume
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: VolumeInfo defines LVM info
+            properties:
+              capacity:
+                description: Capacity of the volume
+                minLength: 1
+                type: string
+              ownerNodeID:
+                description: OwnerNodeID is the Node ID where the volume group is
+                  present which is where the volume has been provisioned. OwnerNodeID
+                  can not be edited after the volume has been provisioned.
+                minLength: 1
+                type: string
+              shared:
+                description: Shared specifies whether the volume can be shared among
+                  multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
+                  will not allow the volumes to be mounted by more than one pods.
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              volGroup:
+                description: VolGroup specifies the name of the volume group where
+                  the volume has been created.
+                minLength: 1
+                type: string
+            required:
+            - capacity
+            - ownerNodeID
+            - volGroup
+            type: object
+          status:
+            description: VolStatus string that specifies the current state of the
+              volume provisioning request.
+            properties:
+              error:
+                description: Error denotes the error occurred during provisioning/expanding
+                  a volume. Error field should only be set when State becomes Failed.
+                properties:
+                  code:
+                    description: VolumeErrorCode represents the error code to represent
+                      specific class of errors.
+                    type: string
+                  message:
+                    type: string
+                type: object
+              state:
+                description: State specifies the current state of the volume provisioning
+                  request. The state "Pending" means that the volume creation request
+                  has not processed yet. The state "Ready" means that the volume has
+                  been created and it is ready for the use. "Failed" means that volume
+                  provisioning has been failed and will not be retried by node agent
+                  controller.
+                enum:
+                - Pending
+                - Ready
+                - Failed
+                type: string
+            type: object
+        required:
+        - spec
+        type: object
     served: true
     storage: true
+    subresources: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>

**Why is this PR required? What issue does it fix?**:
With k8s v1.22 the v1beta1 for various resources will no longer be supported. This PR updates the storage and apiexention version to v1.

**What this PR does?**:

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
