### PR TITLE
fix(thin): use volume group size to create thin pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Features
 - [x] [Snapshot](docs/snapshot.md)
 - [ ] Clone
 - [x] [Volume Resize](docs/resize.md)
+- [x] [Thin Provision](docs/thin_provision.md)
 - [ ] Backup/Restore
 - [ ] Ephemeral inline volume
 

--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -22,8 +22,10 @@ disk=`sudo losetup -f /tmp/disk.img --show`
 sudo pvcreate "$disk"
 sudo vgcreate lvmvg "$disk"
 
-# install snapshot module for lvm
+# install snapshot and thin volume module for lvm
 sudo modprobe dm-snapshot
+sudo modprobe dm_thin_pool
+
 
 LVM_OPERATOR=deploy/lvm-operator.yaml
 SNAP_CLASS=deploy/sample/lvmsnapclass.yaml

--- a/docs/thin_provision.md
+++ b/docs/thin_provision.md
@@ -1,0 +1,63 @@
+## Thin Provisioning
+
+LVM thin provisioning allows you to over-provision the physical storage. You can create
+file systems which are larger than the available physical storage. LVM thin provisioning
+allows you to create virtual disks inside a thin pool. The size of the virtual disk
+can be greater than the available space in the thin pool. It is important that you
+monitor the thin pool and add more capacity when it starts to become full.
+
+
+### Configuring thinProvision volume
+
+For creating thin-provisioned volume, use thinProvision parameter in storage class. It's allowed values are: "yes" and "no". If we don't use this parameter by default it's value will be "no" and it will work as thick provisioned volumes.
+
+```
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+ name: lvm-sc
+allowVolumeExpansion: true
+provisioner: local.csi.openebs.io
+parameters:
+  volgroup: "lvmvg"
+  thinProvision: "yes"
+```
+
+Before creating thin provision volume, make ensure that required thin provisioning kernel module `dm_thin_pool` is loaded on all the nodes.
+
+To verify if the modules are loaded, run:
+```
+lsmod | grep dm_thin_pool
+```
+
+If modules are not loaded, then execute the following command to load the modules:
+```
+modprobe dm_thin_pool
+```
+
+### Extend the Thin Pool size
+
+Thin-pools are just a logical volume, so if we need to extend the size of thin-pool
+we can use the same command like, we have used for logical volumes extend, but we 
+can not reduce the size of thin-pool.
+
+```
+$ lvextend -L +15G lvmvg/thin_pool
+  Extending logical volume thin_pool to 30.00 GiB
+  Logical volume mythinpool successfully resized
+```
+
+### Configure Auto Extending of the Thin Pool (Configure Over-Provisioning protection)
+
+Editing the settings in the `/etc/lvm/lvm.conf` can allow auto growth of the thin 
+pool when required. By default, the threshold is 100% which means that the pool
+will not grow. If we set this to, 75%, the Thin Pool will autoextend when the 
+pool is 75% full. It will increase by the default percentage of 20% if the value
+is not changed. We can see these settings using the command grep against the file.
+
+```
+$ grep -E ‘^\s*thin_pool_auto’ /etc/lvm/lvm.conf 
+  thin_pool_autoextend_threshold = 100
+  thin_pool_autoextend_percent = 20
+```
+

--- a/pkg/lvm/iolimiter_test.go
+++ b/pkg/lvm/iolimiter_test.go
@@ -52,9 +52,9 @@ func TestExtractingIoLimits(t *testing.T) {
 				WBpsLimitPerGB:  nil,
 			}, vgNames: &[]string{"lvmvg1-id1", "lvmvg2", "lvmvg3", "prfx-lvmvg2-sffx"},
 			expected: map[string]expectedIoLimitRate{
-				"lvmvg1-id1": {riops: 50, wiops: 70, rbps: 0, wbps: 0},
-				"lvmvg2":     {riops: 100, wiops: 120, rbps: 0, wbps: 0},
-				"lvmvg3":     {riops: 0, wiops: 0, rbps: 0, wbps: 0},
+				"lvmvg1-id1":       {riops: 50, wiops: 70, rbps: 0, wbps: 0},
+				"lvmvg2":           {riops: 100, wiops: 120, rbps: 0, wbps: 0},
+				"lvmvg3":           {riops: 0, wiops: 0, rbps: 0, wbps: 0},
 				"prfx-lvmvg2-sffx": {riops: 0, wiops: 0, rbps: 0, wbps: 0},
 			},
 		},

--- a/pkg/mgmt/volume/volume.go
+++ b/pkg/mgmt/volume/volume.go
@@ -161,9 +161,12 @@ func (c *VolController) getVgPriorityList(vol *apis.LVMVolume) ([]apis.VolumeGro
 		if !re.MatchString(vg.Name) {
 			continue
 		}
-		// filter vgs having insufficient capacity.
-		if vg.Free.Value() < int64(capacity) {
-			continue
+		// skip the vgs capacity comparison in case of thin provision enable volume
+		if vol.Spec.ThinProvision != "yes" {
+			// filter vgs having insufficient capacity.
+			if vg.Free.Value() < int64(capacity) {
+				continue
+			}
 		}
 		filteredVgs = append(filteredVgs, vg)
 	}

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -90,7 +90,7 @@ func thinVolCreationTest() {
 	By("Deleting application deployment")
 	deleteAppDeployment(appName)
 	By("Deleting pvc")
-	deletePVC(pvcName)
+	deleteAndVerifyPVC(pvcName)
 	By("Deleting thinProvision storage class", deleteStorageClass)
 }
 

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -81,7 +81,21 @@ func blockVolCreationTest() {
 	By("Deleting storage class", deleteStorageClass)
 }
 
+func thinVolCreationTest() {
+	By("Creating thinProvision storage class", createThinStorageClass)
+	By("creating and verifying PVC bound status", createAndVerifyPVC)
+
+	By("Creating and deploying app pod", createDeployVerifyApp)
+	By("verifying LVMVolume object", VerifyLVMVolume)
+	By("Deleting application deployment")
+	deleteAppDeployment(appName)
+	By("Deleting pvc")
+	deletePVC(pvcName)
+	By("Deleting thinProvision storage class", deleteStorageClass)
+}
+
 func volumeCreationTest() {
 	By("Running volume creation test", fsVolCreationTest)
 	By("Running block volume creation test", blockVolCreationTest)
+	By("Running thin volume creation test", thinVolCreationTest)
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -140,6 +140,28 @@ func createStorageClass() {
 	gomega.Expect(err).To(gomega.BeNil(), "while creating a default storageclass {%s}", scName)
 }
 
+func createThinStorageClass() {
+	var (
+		err error
+	)
+
+	parameters := map[string]string{
+		"volgroup":      VOLGROUP,
+		"thinProvision": "yes",
+	}
+
+	ginkgo.By("building a thinProvision storage class")
+	scObj, err = sc.NewBuilder().
+		WithGenerateName(scName).
+		WithParametersNew(parameters).
+		WithProvisioner(LocalProvisioner).Build()
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(),
+		"while building thinProvision storageclass obj with prefix {%s}", scName)
+
+	scObj, err = SCClient.Create(scObj)
+	gomega.Expect(err).To(gomega.BeNil(), "while creating a thinProvision storageclass {%s}", scName)
+}
+
 // VerifyLVMVolume verify the properties of a lvm-volume
 func VerifyLVMVolume() {
 	ginkgo.By("fetching lvm volume")


### PR DESCRIPTION


Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

## Pull Request template


**Why is this PR required? What issue does it fix?**:
Handle the thin pool creation which can not be greater or equal to volumegroup size.
 
**What this PR does?**:

Earlier PV size has been used while thin pool creation, which throws insufficient space error in case if thin volume
size greater or equal then the actual volumegroup size.

As part of this change we are using the half of volumegroup size to make it lesser while creating thin pool.

**Does this PR require any upgrade changes?**:
NO

**If the changes in this PR are manually verified, list down the scenarios covered:**:


**Checklist:**
- [x] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: