### PR TITLE
fix(dockerfile): Add missing xfs package in .buildx file

### DIFF
--- a/buildscripts/lvm-driver/Dockerfile.buildx
+++ b/buildscripts/lvm-driver/Dockerfile.buildx
@@ -43,7 +43,7 @@ RUN make buildx.csi-driver
 
 FROM alpine:3.12
 RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
-RUN apk add --no-cache btrfs-progs xfsprogs e2fsprogs e2fsprogs-extra
+RUN apk add --no-cache btrfs-progs xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates libc6-compat
 
 ARG DBUILD_DATE


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

## Pull Request template

Fix: #53 

- Add missing xfs package `xfsprogs-extra` in .buildx file
