### PR TITLE
fix(provision): prevent volume deletion if snapshot exists

### DIFF
--- a/changelogs/unreleased/55-akhilerm
+++ b/changelogs/unreleased/55-akhilerm
@@ -1,0 +1,1 @@
+prevent LVM volume deletion if a snapshot exists for the volume.

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -432,8 +432,11 @@ func lvThinExists(vg string, name string) bool {
 	return name == strings.TrimSpace(string(out))
 }
 
-func snapshotExists(snapVolumePath string) (bool, error) {
-	if _, err := os.Stat(snapVolumePath); err != nil {
+// snapshotExists checks if a snapshot volume exists given the name of the volume.
+// The name should be <vg-name>/<snapshot-name>
+func snapshotExists(snapVolumeName string) (bool, error) {
+	snapPath := DevPath + snapVolumeName
+	if _, err := os.Stat(snapPath); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -294,6 +294,17 @@ func CreateSnapshot(snap *apis.LVMSnapshot) error {
 func DestroySnapshot(snap *apis.LVMSnapshot) error {
 	snapVolume := snap.Spec.VolGroup + "/" + getLVMSnapName(snap.Name)
 
+	ok, err := snapshotExists(snapVolume)
+	if !ok {
+		klog.Infof("lvm: snapshot %s does not exist, skipping deletion", snapVolume)
+		return nil
+	}
+
+	if err != nil {
+		klog.Errorf("lvm: error checking for snapshot %s, error: %v", snapVolume, err)
+		return err
+	}
+
 	args := buildLVMSnapDestroyArgs(snap)
 	cmd := exec.Command(LVRemove, args...)
 	out, err := cmd.CombinedOutput()
@@ -419,4 +430,14 @@ func lvThinExists(vg string, name string) bool {
 		return false
 	}
 	return name == strings.TrimSpace(string(out))
+}
+
+func snapshotExists(snapVolumePath string) (bool, error) {
+	if _, err := os.Stat(snapVolumePath); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }

--- a/pkg/mgmt/snapshot/snapshot.go
+++ b/pkg/mgmt/snapshot/snapshot.go
@@ -79,7 +79,7 @@ func (c *SnapController) syncSnap(snap *apis.LVMSnapshot) error {
 	if c.isDeletionCandidate(snap) {
 		err = lvm.DestroySnapshot(snap)
 		if err == nil {
-			lvm.RemoveSnapFinalizer(snap)
+			err = lvm.RemoveSnapFinalizer(snap)
 		}
 	} else {
 		// if the status of the snapshot resource is Pending, then

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -48,12 +48,15 @@ func fsVolCreationTest() {
 			resizeAndVerifyPVC(false, "10Gi")
 		}
 
+		// delete PVC should fail if snapshot is present
+		deleteAndVerifyPVC(false, pvcName)
+
 		By("Deleting the application deployment")
 		deleteAppDeployment(appName)
 
 		By("Deleting snapshot and pvc")
 		deleteSnapshot(pvcName, snapName)
-		deletePVC(pvcName)
+		deleteAndVerifyPVC(true, pvcName)
 		By("Deleting storage class", deleteStorageClass)
 	}
 }
@@ -67,7 +70,7 @@ func blockVolCreationTest() {
 	By("Deleting application deployment")
 	deleteAppDeployment(appName)
 	By("Deleting pvc")
-	deletePVC(pvcName)
+	deleteAndVerifyPVC(pvcName)
 	By("Deleting storage class", deleteStorageClass)
 }
 

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -48,8 +48,10 @@ func fsVolCreationTest() {
 			resizeAndVerifyPVC(false, "10Gi")
 		}
 
-		// delete PVC should fail if snapshot is present
-		deleteAndVerifyPVC(false, pvcName)
+		// delete PVC should succeed and PV should not be removed
+		deleteAndVerifyPVC(true, pvcName)
+		// PV should be present after PVC deletion
+		verifyPVForPVC(true, pvcName)
 
 		By("Deleting the application deployment")
 		deleteAppDeployment(appName)
@@ -70,7 +72,7 @@ func blockVolCreationTest() {
 	By("Deleting application deployment")
 	deleteAppDeployment(appName)
 	By("Deleting pvc")
-	deleteAndVerifyPVC(pvcName)
+	deleteAndVerifyPVC(true, pvcName)
 	By("Deleting storage class", deleteStorageClass)
 }
 

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -48,17 +48,22 @@ func fsVolCreationTest() {
 			resizeAndVerifyPVC(false, "10Gi")
 		}
 
-		// delete PVC should succeed and PV should not be removed
-		deleteAndVerifyPVC(true, pvcName)
-		// PV should be present after PVC deletion
-		verifyPVForPVC(true, pvcName)
-
 		By("Deleting the application deployment")
 		deleteAppDeployment(appName)
 
-		By("Deleting snapshot and pvc")
+		// delete PVC should succeed
+		By("Deleting the PVC")
+		deleteAndVerifyPVC(pvcName)
+
+		// PV should be present after PVC deletion since snapshot is present
+		By("Verifying that PV exists after PVC deletion")
+		verifyPVForPVC(true, pvcName)
+
+		By("Deleting snapshot")
 		deleteSnapshot(pvcName, snapName)
-		deleteAndVerifyPVC(true, pvcName)
+
+		By("Verifying that PV is deleted after snapshot deletion")
+		verifyPVForPVC(false, pvcName)
 		By("Deleting storage class", deleteStorageClass)
 	}
 }
@@ -72,7 +77,7 @@ func blockVolCreationTest() {
 	By("Deleting application deployment")
 	deleteAppDeployment(appName)
 	By("Deleting pvc")
-	deleteAndVerifyPVC(true, pvcName)
+	deleteAndVerifyPVC(pvcName)
 	By("Deleting storage class", deleteStorageClass)
 }
 

--- a/tests/pv/build.go
+++ b/tests/pv/build.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The OpenEBS Authors
+Copyright 2021 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/pv/build.go
+++ b/tests/pv/build.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// Builder is the builder object for PV
+type Builder struct {
+	pv   *PV
+	errs []error
+}
+
+// NewBuilder returns new instance of Builder
+func NewBuilder() *Builder {
+	return &Builder{pv: &PV{object: &corev1.PersistentVolume{}}}
+}
+
+// WithName sets the Name field of PV with provided value.
+func (b *Builder) WithName(name string) *Builder {
+	if len(name) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build PV object: missing PV name"))
+		return b
+	}
+	b.pv.object.Name = name
+	return b
+}
+
+// WithAnnotations sets the Annotations field of PV with provided arguments
+func (b *Builder) WithAnnotations(annotations map[string]string) *Builder {
+	if len(annotations) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build PV object: missing annotations"))
+		return b
+	}
+	b.pv.object.Annotations = annotations
+	return b
+}
+
+// WithLabels sets the Labels field of PV with provided arguments
+func (b *Builder) WithLabels(labels map[string]string) *Builder {
+	if len(labels) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build PV object: missing labels"))
+		return b
+	}
+	b.pv.object.Labels = labels
+	return b
+}
+
+// WithReclaimPolicy sets the PV ReclaimPolicy field with provided argument
+func (b *Builder) WithReclaimPolicy(reclaimPolicy corev1.PersistentVolumeReclaimPolicy) *Builder {
+	b.pv.object.Spec.PersistentVolumeReclaimPolicy = reclaimPolicy
+	return b
+}
+
+// WithVolumeMode sets the VolumeMode field in PV with provided arguments
+func (b *Builder) WithVolumeMode(volumeMode corev1.PersistentVolumeMode) *Builder {
+	b.pv.object.Spec.VolumeMode = &volumeMode
+	return b
+}
+
+// WithAccessModes sets the AccessMode field in PV with provided arguments
+func (b *Builder) WithAccessModes(accessMode []corev1.PersistentVolumeAccessMode) *Builder {
+	if len(accessMode) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build PV object: missing accessmodes"))
+		return b
+	}
+	b.pv.object.Spec.AccessModes = accessMode
+	return b
+}
+
+// WithCapacity sets the Capacity field in PV by converting string
+// capacity into Quantity
+func (b *Builder) WithCapacity(capacity string) *Builder {
+	resCapacity, err := resource.ParseQuantity(capacity)
+	if err != nil {
+		b.errs = append(b.errs, errors.Wrapf(err, "failed to build PV object: failed to parse capacity {%s}", capacity))
+		return b
+	}
+	return b.WithCapacityQty(resCapacity)
+}
+
+// WithCapacityQty sets the Capacity field in PV with provided arguments
+func (b *Builder) WithCapacityQty(resCapacity resource.Quantity) *Builder {
+	resourceList := corev1.ResourceList{
+		corev1.ResourceName(corev1.ResourceStorage): resCapacity,
+	}
+	b.pv.object.Spec.Capacity = resourceList
+	return b
+}
+
+// WithLocalHostDirectory sets the LocalVolumeSource field of PV with provided hostpath
+func (b *Builder) WithLocalHostDirectory(path string) *Builder {
+	return b.WithLocalHostPathFormat(path, "")
+}
+
+// WithLocalHostPathFormat sets the LocalVolumeSource field of PV with provided hostpath
+// and request to format it with fstype - if not already formatted. A "" value for fstype
+// indicates that the Local PV can determine the type of FS.
+func (b *Builder) WithLocalHostPathFormat(path, fstype string) *Builder {
+	if len(path) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build PV object: missing PV path"))
+		return b
+	}
+	volumeSource := corev1.PersistentVolumeSource{
+		Local: &corev1.LocalVolumeSource{
+			Path:   path,
+			FSType: &fstype,
+		},
+	}
+
+	b.pv.object.Spec.PersistentVolumeSource = volumeSource
+	return b
+}
+
+// WithPersistentVolumeSource sets the volume source field of PV with provided source
+func (b *Builder) WithPersistentVolumeSource(source *corev1.PersistentVolumeSource) *Builder {
+	if source == nil {
+		b.errs = append(b.errs, errors.New("failed to build PV object: missing PV source"))
+		return b
+	}
+	b.pv.object.Spec.PersistentVolumeSource = *source
+	return b
+}
+
+// WithNodeAffinity sets the NodeAffinity field of PV with provided node name
+func (b *Builder) WithNodeAffinity(nodeName string) *Builder {
+	if len(nodeName) == 0 {
+		b.errs = append(b.errs, errors.New("failed to build PV object: missing PV node name"))
+		return b
+	}
+	nodeAffinity := &corev1.VolumeNodeAffinity{
+		Required: &corev1.NodeSelector{
+			NodeSelectorTerms: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Key:      KeyNode,
+							Operator: corev1.NodeSelectorOpIn,
+							Values: []string{
+								nodeName,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	b.pv.object.Spec.NodeAffinity = nodeAffinity
+	return b
+}
+
+// Build returns the PV API instance
+func (b *Builder) Build() (*corev1.PersistentVolume, error) {
+	if len(b.errs) > 0 {
+		return nil, errors.Errorf("%+v", b.errs)
+	}
+	return b.pv.object, nil
+}

--- a/tests/pv/build.go
+++ b/tests/pv/build.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package pv
 
 import (
 	"github.com/pkg/errors"

--- a/tests/pv/buildlist.go
+++ b/tests/pv/buildlist.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2019 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ListBuilder enables building an instance of
+// PVlist
+type ListBuilder struct {
+	list    *PVList
+	filters PredicateList
+	errs    []error
+}
+
+// NewListBuilder returns an instance of ListBuilder
+func NewListBuilder() *ListBuilder {
+	return &ListBuilder{list: &PVList{}}
+}
+
+// ListBuilderForAPIObjects builds the ListBuilder object based on PV api list
+func ListBuilderForAPIObjects(pvs *corev1.PersistentVolumeList) *ListBuilder {
+	b := &ListBuilder{list: &PVList{}}
+	if pvs == nil {
+		b.errs = append(b.errs, errors.New("failed to build pv list: missing api list"))
+		return b
+	}
+	for _, pv := range pvs.Items {
+		pv := pv
+		b.list.items = append(b.list.items, &PV{object: &pv})
+	}
+	return b
+}
+
+// ListBuilderForObjects builds the ListBuilder object based on PVList
+func ListBuilderForObjects(pvs *PVList) *ListBuilder {
+	b := &ListBuilder{}
+	if pvs == nil {
+		b.errs = append(b.errs, errors.New("failed to build pv list: missing object list"))
+		return b
+	}
+	b.list = pvs
+	return b
+}
+
+// List returns the list of pv
+// instances that was built by this
+// builder
+func (b *ListBuilder) List() (*PVList, error) {
+	if len(b.errs) > 0 {
+		return nil, errors.Errorf("failed to list pv: %+v", b.errs)
+	}
+	if b.filters == nil || len(b.filters) == 0 {
+		return b.list, nil
+	}
+	filteredList := &PVList{}
+	for _, pv := range b.list.items {
+		if b.filters.all(pv) {
+			filteredList.items = append(filteredList.items, pv)
+		}
+	}
+	return filteredList, nil
+}
+
+// Len returns the number of items present
+// in the PVCList of a builder
+func (b *ListBuilder) Len() (int, error) {
+	l, err := b.List()
+	if err != nil {
+		return 0, err
+	}
+	return l.Len(), nil
+}
+
+// APIList builds core API PV list using listbuilder
+func (b *ListBuilder) APIList() (*corev1.PersistentVolumeList, error) {
+	l, err := b.List()
+	if err != nil {
+		return nil, err
+	}
+	return l.ToAPIList(), nil
+}

--- a/tests/pv/buildlist.go
+++ b/tests/pv/buildlist.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The OpenEBS Authors
+Copyright 2021 The OpenEBS Authors
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/tests/pv/buildlist.go
+++ b/tests/pv/buildlist.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha1
+package pv
 
 import (
 	"github.com/pkg/errors"

--- a/tests/pv/kubernetes.go
+++ b/tests/pv/kubernetes.go
@@ -1,16 +1,18 @@
-// Copyright © 2018-2019 The OpenEBS Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pv
 

--- a/tests/pv/kubernetes.go
+++ b/tests/pv/kubernetes.go
@@ -1,0 +1,228 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"strings"
+
+	"github.com/openebs/lib-csi/pkg/common/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openebs/lib-csi/pkg/common/kubernetes/client"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	//KeyNode represents the key values used for specifying the Node Affinity
+	// based on the hostname
+	KeyNode = "kubernetes.io/hostname"
+)
+
+// getClientsetFn is a typed function that
+// abstracts fetching of clientset
+type getClientsetFn func() (clientset *kubernetes.Clientset, err error)
+
+// getClientsetFromPathFn is a typed function that
+// abstracts fetching of clientset from kubeConfigPath
+type getClientsetForPathFn func(kubeConfigPath string) (clientset *kubernetes.Clientset, err error)
+
+// getpvcFn is a typed function that
+// abstracts fetching of pv
+type getFn func(cli *kubernetes.Clientset, name string, opts metav1.GetOptions) (*corev1.PersistentVolume, error)
+
+// listFn is a typed function that abstracts
+// listing of pvs
+type listFn func(cli *kubernetes.Clientset, opts metav1.ListOptions) (*corev1.PersistentVolumeList, error)
+
+// deleteFn is a typed function that abstracts
+// deletion of pvs
+type deleteFn func(cli *kubernetes.Clientset, name string, deleteOpts *metav1.DeleteOptions) error
+
+// deleteFn is a typed function that abstracts
+// deletion of pv's collection
+type deleteCollectionFn func(cli *kubernetes.Clientset, listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error
+
+// createFn is a typed function that abstracts
+// creation of pv
+type createFn func(cli *kubernetes.Clientset, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error)
+
+// Kubeclient enables kubernetes API operations
+// on pv instance
+type Kubeclient struct {
+	// clientset refers to pvc clientset
+	// that will be responsible to
+	// make kubernetes API calls
+	clientset *kubernetes.Clientset
+
+	// kubeconfig path to get kubernetes clientset
+	kubeConfigPath string
+
+	// functions useful during mocking
+	getClientset        getClientsetFn
+	getClientsetForPath getClientsetForPathFn
+	list                listFn
+	get                 getFn
+	create              createFn
+	del                 deleteFn
+	delCollection       deleteCollectionFn
+}
+
+// KubeclientBuildOption abstracts creating an
+// instance of kubeclient
+type KubeclientBuildOption func(*Kubeclient)
+
+// withDefaults sets the default options
+// of kubeclient instance
+func (k *Kubeclient) withDefaults() {
+	if k.getClientset == nil {
+		k.getClientset = func() (clients *kubernetes.Clientset, err error) {
+			return client.New().Clientset()
+		}
+	}
+	if k.getClientsetForPath == nil {
+		k.getClientsetForPath = func(kubeConfigPath string) (clients *kubernetes.Clientset, err error) {
+			return client.New(client.WithKubeConfigPath(kubeConfigPath)).Clientset()
+		}
+	}
+	if k.get == nil {
+		k.get = func(cli *kubernetes.Clientset, name string, opts metav1.GetOptions) (*corev1.PersistentVolume, error) {
+			return cli.CoreV1().PersistentVolumes().Get(name, opts)
+		}
+	}
+	if k.list == nil {
+		k.list = func(cli *kubernetes.Clientset, opts metav1.ListOptions) (*corev1.PersistentVolumeList, error) {
+			return cli.CoreV1().PersistentVolumes().List(opts)
+		}
+	}
+	if k.del == nil {
+		k.del = func(cli *kubernetes.Clientset, name string, deleteOpts *metav1.DeleteOptions) error {
+			return cli.CoreV1().PersistentVolumes().Delete(name, deleteOpts)
+		}
+	}
+	if k.delCollection == nil {
+		k.delCollection = func(cli *kubernetes.Clientset, listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error {
+			return cli.CoreV1().PersistentVolumes().DeleteCollection(deleteOpts, listOpts)
+		}
+	}
+	if k.create == nil {
+		k.create = func(cli *kubernetes.Clientset, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+			return cli.CoreV1().PersistentVolumes().Create(pv)
+		}
+	}
+}
+
+// WithClientSet sets the kubernetes client against
+// the kubeclient instance
+func WithClientSet(c *kubernetes.Clientset) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.clientset = c
+	}
+}
+
+// WithKubeConfigPath sets the kubeConfig path
+// against client instance
+func WithKubeConfigPath(path string) KubeclientBuildOption {
+	return func(k *Kubeclient) {
+		k.kubeConfigPath = path
+	}
+}
+
+// NewKubeClient returns a new instance of kubeclient meant for
+// cstor volume replica operations
+func NewKubeClient(opts ...KubeclientBuildOption) *Kubeclient {
+	k := &Kubeclient{}
+	for _, o := range opts {
+		o(k)
+	}
+	k.withDefaults()
+	return k
+}
+
+func (k *Kubeclient) getClientsetForPathOrDirect() (*kubernetes.Clientset, error) {
+	if k.kubeConfigPath != "" {
+		return k.getClientsetForPath(k.kubeConfigPath)
+	}
+	return k.getClientset()
+}
+
+// getClientsetOrCached returns either a new instance
+// of kubernetes client or its cached copy
+func (k *Kubeclient) getClientsetOrCached() (*kubernetes.Clientset, error) {
+	if k.clientset != nil {
+		return k.clientset, nil
+	}
+
+	cs, err := k.getClientsetForPathOrDirect()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get clientset")
+	}
+	k.clientset = cs
+	return k.clientset, nil
+}
+
+// Get returns a pv resource
+// instances present in kubernetes cluster
+func (k *Kubeclient) Get(name string, opts metav1.GetOptions) (*corev1.PersistentVolume, error) {
+	if strings.TrimSpace(name) == "" {
+		return nil, errors.New("failed to get pv: missing pv name")
+	}
+	cli, err := k.getClientsetOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get pv {%s}", name)
+	}
+	return k.get(cli, name, opts)
+}
+
+// List returns a list of pv
+// instances present in kubernetes cluster
+func (k *Kubeclient) List(opts metav1.ListOptions) (*corev1.PersistentVolumeList, error) {
+	cli, err := k.getClientsetOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list pv listoptions: '%v'", opts)
+	}
+	return k.list(cli, opts)
+}
+
+// Delete deletes a pv instance from the
+// kubecrnetes cluster
+func (k *Kubeclient) Delete(name string, deleteOpts *metav1.DeleteOptions) error {
+	if strings.TrimSpace(name) == "" {
+		return errors.New("failed to delete pvc: missing pv name")
+	}
+	cli, err := k.getClientsetOrCached()
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete pv {%s}", name)
+	}
+	return k.del(cli, name, deleteOpts)
+}
+
+// Create creates a pv in kubernetes cluster
+func (k *Kubeclient) Create(pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+	cli, err := k.getClientsetOrCached()
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create pv: %s", pv.Name)
+	}
+	return k.create(cli, pv)
+}
+
+// DeleteCollection deletes a collection of pv objects.
+func (k *Kubeclient) DeleteCollection(listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error {
+	cli, err := k.getClientsetOrCached()
+	if err != nil {
+		return errors.Wrapf(err, "failed to delete the collection of pvs")
+	}
+	return k.delCollection(cli, listOpts, deleteOpts)
+}

--- a/tests/pv/kubernetes.go
+++ b/tests/pv/kubernetes.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package pv
 
 import (
 	"context"

--- a/tests/pv/kubernetes.go
+++ b/tests/pv/kubernetes.go
@@ -15,6 +15,7 @@
 package v1alpha1
 
 import (
+	"context"
 	"strings"
 
 	"github.com/openebs/lib-csi/pkg/common/errors"
@@ -99,27 +100,27 @@ func (k *Kubeclient) withDefaults() {
 	}
 	if k.get == nil {
 		k.get = func(cli *kubernetes.Clientset, name string, opts metav1.GetOptions) (*corev1.PersistentVolume, error) {
-			return cli.CoreV1().PersistentVolumes().Get(name, opts)
+			return cli.CoreV1().PersistentVolumes().Get(context.TODO(), name, opts)
 		}
 	}
 	if k.list == nil {
 		k.list = func(cli *kubernetes.Clientset, opts metav1.ListOptions) (*corev1.PersistentVolumeList, error) {
-			return cli.CoreV1().PersistentVolumes().List(opts)
+			return cli.CoreV1().PersistentVolumes().List(context.TODO(), opts)
 		}
 	}
 	if k.del == nil {
 		k.del = func(cli *kubernetes.Clientset, name string, deleteOpts *metav1.DeleteOptions) error {
-			return cli.CoreV1().PersistentVolumes().Delete(name, deleteOpts)
+			return cli.CoreV1().PersistentVolumes().Delete(context.TODO(), name, *deleteOpts)
 		}
 	}
 	if k.delCollection == nil {
 		k.delCollection = func(cli *kubernetes.Clientset, listOpts metav1.ListOptions, deleteOpts *metav1.DeleteOptions) error {
-			return cli.CoreV1().PersistentVolumes().DeleteCollection(deleteOpts, listOpts)
+			return cli.CoreV1().PersistentVolumes().DeleteCollection(context.TODO(), *deleteOpts, listOpts)
 		}
 	}
 	if k.create == nil {
 		k.create = func(cli *kubernetes.Clientset, pv *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
-			return cli.CoreV1().PersistentVolumes().Create(pv)
+			return cli.CoreV1().PersistentVolumes().Create(context.TODO(), pv, metav1.CreateOptions{})
 		}
 	}
 }

--- a/tests/pv/persistentvolume.go
+++ b/tests/pv/persistentvolume.go
@@ -1,16 +1,18 @@
-// Copyright © 2018-2019 The OpenEBS Authors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package pv
 

--- a/tests/pv/persistentvolume.go
+++ b/tests/pv/persistentvolume.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1alpha1
+package pv
 
 import (
 	"strings"

--- a/tests/pv/persistentvolume.go
+++ b/tests/pv/persistentvolume.go
@@ -1,0 +1,167 @@
+// Copyright © 2018-2019 The OpenEBS Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PV is a wrapper over persistentvolume api
+// object. It provides build, validations and other common
+// logic to be used by various feature specific callers.
+type PV struct {
+	object *corev1.PersistentVolume
+}
+
+// PVList is a wrapper over persistentvolume api
+// object. It provides build, validations and other common
+// logic to be used by various feature specific callers.
+type PVList struct {
+	items []*PV
+}
+
+// Len returns the number of items present
+// in the PVList
+func (p *PVList) Len() int {
+	return len(p.items)
+}
+
+// ToAPIList converts PVList to API PVList
+func (p *PVList) ToAPIList() *corev1.PersistentVolumeList {
+	plist := &corev1.PersistentVolumeList{}
+	for _, pvc := range p.items {
+		plist.Items = append(plist.Items, *pvc.object)
+	}
+	return plist
+}
+
+type pvBuildOption func(*PV)
+
+// NewForAPIObject returns a new instance of PV
+func NewForAPIObject(obj *corev1.PersistentVolume, opts ...pvBuildOption) *PV {
+	p := &PV{object: obj}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+// Predicate defines an abstraction
+// to determine conditional checks
+// against the provided pvc instance
+type Predicate func(*PV) bool
+
+// IsNil returns true if the PV instance
+// is nil
+func (p *PV) IsNil() bool {
+	return p.object == nil
+}
+
+// GetPath returns path configured on VolumeSource
+// The VolumeSource can be either Local or HostPath
+func (p *PV) GetPath() string {
+	local := p.object.Spec.PersistentVolumeSource.Local
+	if local != nil {
+		return local.Path
+	}
+	//Handle the case of Local PV created in 0.9 using
+	//HostPath VolumeSource
+	hostPath := p.object.Spec.PersistentVolumeSource.HostPath
+	if hostPath != nil {
+		return hostPath.Path
+	}
+	return ""
+}
+
+// GetAffinitedNodeHostname returns hostname configured using the NodeAffinity
+// This method expects only a single hostname to be set.
+//
+// The PV object will have the node's hostname specified as follows:
+//   nodeAffinity:
+//     required:
+//       nodeSelectorTerms:
+//       - matchExpressions:
+//         - key: kubernetes.io/hostname
+//           operator: In
+//           values:
+//           - hostname
+//
+func (p *PV) GetAffinitedNodeHostname() string {
+	nodeAffinity := p.object.Spec.NodeAffinity
+	if nodeAffinity == nil {
+		return ""
+	}
+	required := nodeAffinity.Required
+	if required == nil {
+		return ""
+	}
+
+	hostname := ""
+	for _, selectorTerm := range required.NodeSelectorTerms {
+		for _, expression := range selectorTerm.MatchExpressions {
+			if expression.Key == KeyNode &&
+				expression.Operator == corev1.NodeSelectorOpIn {
+				if len(expression.Values) != 1 {
+					return ""
+				}
+				hostname = expression.Values[0]
+				break
+			}
+		}
+		if hostname != "" {
+			break
+		}
+	}
+	return hostname
+}
+
+// IsNil is predicate to filter out nil PV
+// instances
+func IsNil() Predicate {
+	return func(p *PV) bool {
+		return p.IsNil()
+	}
+}
+
+// ContainsName is filter function to filter pv's
+// based on the name
+func ContainsName(name string) Predicate {
+	return func(p *PV) bool {
+		return strings.Contains(p.object.GetName(), name)
+	}
+}
+
+// PredicateList holds a list of predicate
+type PredicateList []Predicate
+
+// all returns true if all the predicates
+// succeed against the provided pv
+// instance
+func (l PredicateList) all(p *PV) bool {
+	for _, pred := range l {
+		if !pred(p) {
+			return false
+		}
+	}
+	return true
+}
+
+// WithFilter adds filters on which the pv's has to be filtered
+func (b *ListBuilder) WithFilter(pred ...Predicate) *ListBuilder {
+	b.filters = append(b.filters, pred...)
+	return b
+}

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/openebs/lvm-localpv/pkg/builder/volbuilder"
 	"github.com/openebs/lvm-localpv/tests/deploy"
 	"github.com/openebs/lvm-localpv/tests/pod"
+	"github.com/openebs/lvm-localpv/tests/pv"
 	"github.com/openebs/lvm-localpv/tests/pvc"
 	"github.com/openebs/lvm-localpv/tests/sc"
 	appsv1 "k8s.io/api/apps/v1"
@@ -45,6 +46,7 @@ var (
 	LVMClient        *volbuilder.Kubeclient
 	SCClient         *sc.Kubeclient
 	PVCClient        *pvc.Kubeclient
+	PVClient         *pv.Kubeclient
 	DeployClient     *deploy.Kubeclient
 	PodClient        *pod.KubeClient
 	nsName           = "lvm"

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -76,6 +76,7 @@ func init() {
 	}
 	SCClient = sc.NewKubeClient(sc.WithKubeConfigPath(KubeConfigPath))
 	PVCClient = pvc.NewKubeClient(pvc.WithKubeConfigPath(KubeConfigPath))
+	PVClient = pv.NewKubeClient(pv.WithKubeConfigPath(KubeConfigPath))
 	DeployClient = deploy.NewKubeClient(deploy.WithKubeConfigPath(KubeConfigPath))
 	PodClient = pod.NewKubeClient(pod.WithKubeConfigPath(KubeConfigPath))
 	LVMClient = volbuilder.NewKubeclient(volbuilder.WithKubeConfigPath(KubeConfigPath))

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -46,7 +46,7 @@ var (
 	LVMClient        *volbuilder.Kubeclient
 	SCClient         *sc.Kubeclient
 	PVCClient        *pvc.Kubeclient
-	PVClient         *pv.Kubeclient
+	PVlient          *pv.Kubeclient
 	DeployClient     *deploy.Kubeclient
 	PodClient        *pod.KubeClient
 	nsName           = "lvm"

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -46,7 +46,7 @@ var (
 	LVMClient        *volbuilder.Kubeclient
 	SCClient         *sc.Kubeclient
 	PVCClient        *pvc.Kubeclient
-	PVlient          *pv.Kubeclient
+	PVClient         *pv.Kubeclient
 	DeployClient     *deploy.Kubeclient
 	PodClient        *pod.KubeClient
 	nsName           = "lvm"

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -476,9 +476,9 @@ func verifyPVForPVC(shouldExist bool, pvcName string) {
 	ginkgo.By("verifying PVC for deleted PV exists")
 	matchingPVFound := gomega.BeFalse()
 	for _, pv := range pvList.Items {
-		if pv.claimRef != nil &&
-			pv.claimRef.name == pvcName &&
-			pv.claimRef.namespace == OpenEBSNamespace {
+		if pv.Spec.ClaimRef != nil &&
+			pv.Spec.ClaimRef.Name == pvcName &&
+			pv.Spec.ClaimRef.Namespace == OpenEBSNamespace {
 			matchingPVFound = gomega.BeTrue()
 		}
 	}

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -473,6 +473,7 @@ func verifyPVForPVC(shouldExist bool, pvcName string) {
 		shouldPVExist = gomega.BeTrue()
 	}
 
+	ginkgo.By("verifying PVC for deleted PV exists")
 	matchingPVFound := gomega.BeFalse()
 	for _, pv := range pvList.Items {
 		if pv.claimRef != nil &&

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -459,3 +459,27 @@ func deleteAndVerifyPVC(shouldPass bool, pvcname string) {
 	status := IsPVCDeletedEventually(pvcname, shouldPass)
 	gomega.Expect(status).To(gomega.Equal(true), "while trying to get deleted pvc")
 }
+
+func verifyPVForPVC(shouldExist bool, pvcName string) {
+	pvList, err := PVClient.List(metav1.ListOptions{})
+	gomega.Expect(err).To(
+		gomega.BeNil(),
+		"while listing PV for PVC: %{s}",
+		pvcName,
+	)
+
+	shouldPVExist := gomega.BeFalse()
+	if shouldExist {
+		shouldPVExist = gomega.BeTrue()
+	}
+
+	matchingPVFound := gomega.BeFalse()
+	for _, pv := range pvList.Items {
+		if pv.claimRef != nil &&
+			pv.claimRef.name == pvcName &&
+			pv.claimRef.namespace == OpenEBSNamespace {
+			matchingPVFound = gomega.BeTrue()
+		}
+	}
+	gomega.Expect(matchingPVFound).To(shouldPVExist)
+}


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
When an LVM volume  with active snapshot is deleted, both volume and snapshot is removed from the machine, but the resources corresponding to the snapshot still exists in the cluster. This stale snapshot resources will cause the controller to error out when we try to delete these resources as the actual snapshot does not exist.

**What this PR does?**:
- error out the DeleteVolume() controller gRPC call if the volume has active snapshots

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: