### PR TITLE
fix(provisioning) add ^ and $ anchors for exact match of existing vol…

### DIFF
--- a/pkg/driver/params.go
+++ b/pkg/driver/params.go
@@ -56,9 +56,11 @@ func NewVolumeParams(m map[string]string) (*VolumeParams, error) {
 
 	// for ensuring backward compatibility, we first check if
 	// there is any volgroup param exists for storage class.
-	vgPattern, ok := m["volgroup"]
-	if !ok {
-		vgPattern = m["vgpattern"]
+
+	vgPattern := m["vgpattern"]
+	volGroup, ok := m["volgroup"]
+	if ok {
+		vgPattern = fmt.Sprintf("^%v$", volGroup)
 	}
 
 	var err error


### PR DESCRIPTION
…Group param

**Why is this PR required? What issue does it fix?**:
As of now in absence of vgPattern storage class param, we default it with existing volgroup param. Since it's an exact match, we need to add start(`^`) & end(`$`) anchors to avoid treating it as substring match. See [this](https://play.golang.org/p/O9RYIffzGn-) for more details.

**What this PR does?**:
Ensure exact regex match by adding start and end string anchors.

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_
#28 

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
