### PR TITLE
[stable/lvm]: update helm charts to 0.5.0 release

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -45,8 +45,10 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.1.0
         if: steps.list-changed.outputs.changed == 'true'
+        with:
+          config: buildscripts/kind_config.yaml
 
       - name: Run chart-testing (install)
         run: ct install --config ct.yaml

--- a/buildscripts/kind_config.yaml
+++ b/buildscripts/kind_config.yaml
@@ -1,0 +1,6 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+featureGates:
+  "CSIStorageCapacity": true
+runtimeConfig:
+  "api/alpha": "true"

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 0.4.0
-appVersion: 0.4.0
+version: 0.5.0
+appVersion: 0.5.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/
 keywords:

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -77,7 +77,7 @@ The following table lists the configurable parameters of the OpenEBS LVM Localpv
 | `lvmPlugin.image.registry`| Registry for openebs-lvm-plugin image| `""`|
 | `lvmPlugin.image.repository`| Image repository for openebs-lvm-plugin| `openebs/lvm-driver`|
 | `lvmPlugin.image.pullPolicy`| Image pull policy for openebs-lvm-plugin| `IfNotPresent`|
-| `lvmPlugin.image.tag`| Image tag for openebs-lvm-plugin| `0.4.0`|
+| `lvmPlugin.image.tag`| Image tag for openebs-lvm-plugin| `0.5.0`|
 | `lvmNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `k8s.gcr.io/`|
 | `lvmNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|
 | `lvmNode.driverRegistrar.image.pullPolicy`| Image pull policy for csi-node-driver-registrar| `IfNotPresent`|

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 release:
-  version: "0.4.0"
+  version: "0.5.0"
 
 imagePullSecrets:
 # - name: "image-pull-secret"
@@ -126,7 +126,7 @@ lvmPlugin:
     repository: openebs/lvm-driver
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: 0.4.0
+    tag: 0.5.0
   ioLimits:
     enabled: false
     containerRuntime: containerd


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

**What this PR does?**:
Bump lvm localpv charts to 0.5.0 

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: