### PR TITLE
chore(linter): add golangci-lint tool for checking the gocode base

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,11 @@ jobs:
           pattern: '*.sh'
           exclude: './.git/*,./vendor/*'
 
+      - name: install golangci-lint
+        run: make install-golangci-lint
+
+      - name: Lint checks
+        run: make golint
 
   unit-test:
     # to ignore builds on release

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,23 @@
+# This file contains all available configuration options
+# with their default values.
+
+run:
+  # which dirs to skip: issues from them won't be reported;
+  # can use regexp here: generated.*, regexp is applied on full path;
+  # default value is empty list, but default dirs are skipped independently
+  # from this option's value
+  skip-dirs:
+    - tests
+
+# all available settings of specific linters
+linters-settings:
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+    ## No function should take more than 5 arguments
+    ## since it affect readability of code
+    - name: argument-limit
+      severity: warning
+      arguments:
+      - 5

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -37,7 +37,8 @@ import (
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 // node is the server implementation
@@ -384,7 +385,7 @@ func (ns *node) NodeGetVolumeStats(
 		return nil, status.Error(codes.InvalidArgument, "path is not provided")
 	}
 
-	if mount.IsMountPath(path) == false {
+	if !mount.IsMountPath(path) {
 		return nil, status.Error(codes.NotFound, "path is not a mount path")
 	}
 

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -27,7 +27,7 @@ import (
 	informers "github.com/openebs/lvm-localpv/pkg/generated/informer/externalversions"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
@@ -149,7 +149,7 @@ func waitForLVMVolume(ctx context.Context,
 		errMsg = volErr.Message
 		reschedule = true
 	} else {
-		errMsg = fmt.Sprintf("failed lvmvol must have error set")
+		errMsg = "failed lvmvol must have error set"
 	}
 
 	if reschedule {
@@ -792,18 +792,6 @@ func (cs *controller) ListVolumes(
 ) (*csi.ListVolumesResponse, error) {
 
 	return nil, status.Error(codes.Unimplemented, "")
-}
-
-// validateCapabilities validates if provided capabilities
-// are supported by this driver
-func validateCapabilities(caps []*csi.VolumeCapability) bool {
-
-	for _, cap := range caps {
-		if !IsSupportedVolumeCapabilityAccessMode(cap.AccessMode.Mode) {
-			return false
-		}
-	}
-	return true
 }
 
 func (cs *controller) validateDeleteVolumeReq(req *csi.DeleteVolumeRequest) error {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -22,13 +22,6 @@ import (
 	"k8s.io/klog"
 )
 
-// volume can only be published once as
-// read/write on a single node, at any
-// given time
-var supportedAccessMode = &csi.VolumeCapability_AccessMode{
-	Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
-}
-
 // CSIDriver defines a common data structure
 // for drivers
 // TODO check if this can be renamed to Base

--- a/pkg/driver/grpc.go
+++ b/pkg/driver/grpc.go
@@ -68,13 +68,13 @@ func isInfotrmativeLog(info string) bool {
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 
 	log := isInfotrmativeLog(info.FullMethod)
-	if log == true {
+	if log {
 		klog.Infof("GRPC call: %s requests %s", info.FullMethod, protosanitizer.StripSecrets(req))
 	}
 
 	resp, err := handler(ctx, req)
 
-	if log == true {
+	if log {
 		if err != nil {
 			klog.Errorf("GRPC error: %v", err)
 		} else {
@@ -126,8 +126,6 @@ func (s *nonBlockingGRPCServer) Start() {
 	s.wg.Add(1)
 
 	go s.serve(s.endpoint, s.idntyServer, s.ctrlServer, s.agentServer)
-
-	return
 }
 
 // Wait for the service to stop
@@ -192,6 +190,9 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 	klog.Infof("Listening for connections on address: %#v", listener.Addr())
 
 	// Start serving requests on the grpc server created
-	server.Serve(listener)
+	err = server.Serve(listener)
+	if err != nil {
+		klog.Fatalf("Failed to start server error: %v", err)
+	}
 
 }

--- a/pkg/lvm/iolimiter.go
+++ b/pkg/lvm/iolimiter.go
@@ -39,10 +39,7 @@ var (
 func isSet() bool {
 	rwlock.RLock()
 	defer rwlock.RUnlock()
-	if set {
-		return true
-	}
-	return false
+	return set
 }
 
 func extractRateValues(rateVals *[]string) (map[string]uint64, error) {

--- a/pkg/lvm/mount.go
+++ b/pkg/lvm/mount.go
@@ -300,7 +300,10 @@ func setIOLimits(vol *apis.LVMVolume, podLVInfo *PodLVInfo, devicePath string) e
 
 func makeFile(pathname string) error {
 	f, err := os.OpenFile(pathname, os.O_CREATE, os.FileMode(0644))
-	defer f.Close()
+	defer func(f *os.File) {
+		err = f.Close()
+		klog.Errorf("failed to close file %s error: %v", f.Name(), err)
+	}(f)
 	if err != nil {
 		if !os.IsExist(err) {
 			return err

--- a/pkg/mgmt/lvmnode/lvmnode.go
+++ b/pkg/mgmt/lvmnode/lvmnode.go
@@ -78,7 +78,7 @@ func (c *NodeController) syncNode(namespace string, name string) error {
 		}
 
 		klog.Infof("lvm node controller: creating new node object for %+v", node)
-		if node, err = nodebuilder.NewKubeclient().WithNamespace(namespace).Create(node); err != nil {
+		if _, err = nodebuilder.NewKubeclient().WithNamespace(namespace).Create(node); err != nil {
 			return fmt.Errorf("create lvm node %s/%s: %v", namespace, name, err)
 		}
 		klog.Infof("lvm node controller: created node object %s/%s", namespace, name)
@@ -108,7 +108,7 @@ func (c *NodeController) syncNode(namespace string, name string) error {
 	}
 
 	klog.Infof("lvm node controller: updating node object with %+v", node)
-	if node, err = nodebuilder.NewKubeclient().WithNamespace(namespace).Update(node); err != nil {
+	if _, err = nodebuilder.NewKubeclient().WithNamespace(namespace).Update(node); err != nil {
 		return fmt.Errorf("update lvm node %s/%s: %v", namespace, name, err)
 	}
 	klog.Infof("lvm node controller: updated node object %s/%s", namespace, name)

--- a/pkg/usage/usage.go
+++ b/pkg/usage/usage.go
@@ -195,7 +195,7 @@ func (u *Usage) SetValue(v int64) *Usage {
 func (u *Usage) Build() *Usage {
 	// Default ApplicationID for openebs project is OpenEBS
 	v := NewVersion()
-	v.getVersion(false)
+	_ = v.getVersion(false)
 	u.SetApplicationID(AppName).
 		SetTrackingID(GAclientID).
 		SetClientID(v.id).
@@ -209,7 +209,7 @@ func (u *Usage) Build() *Usage {
 // for non install events
 func (u *Usage) ApplicationBuilder() *Usage {
 	v := NewVersion()
-	v.getVersion(false)
+	_ = v.getVersion(false)
 	u.SetApplicationVersion(v.openebsVersion).
 		SetApplicationName(v.k8sArch).
 		SetApplicationInstallerID(v.k8sVersion).
@@ -255,7 +255,7 @@ func (u *Usage) SetReplicaCount(count, method string) *Usage {
 func (u *Usage) InstallBuilder(override bool) *Usage {
 	v := NewVersion()
 	clusterSize, _ := k8sapi.NumberOfNodes()
-	v.getVersion(override)
+	_ = v.getVersion(override)
 	u.SetApplicationVersion(v.openebsVersion).
 		SetApplicationName(v.k8sArch).
 		SetApplicationInstallerID(v.k8sVersion).

--- a/pkg/usage/versionset.go
+++ b/pkg/usage/versionset.go
@@ -57,7 +57,7 @@ func (v *VersionSet) fetchAndSetVersion() error {
 	if err != nil {
 		return err
 	}
-	env.Set(clusterUUID, v.id)
+	_ = env.Set(clusterUUID, v.id)
 
 	k8s, err := k8sapi.GetServerVersion()
 	if err != nil {
@@ -66,15 +66,16 @@ func (v *VersionSet) fetchAndSetVersion() error {
 	// eg. linux/amd64
 	v.k8sArch = k8s.Platform
 	v.k8sVersion = k8s.GitVersion
-	env.Set(clusterArch, v.k8sArch)
-	env.Set(clusterVersion, v.k8sVersion)
+	// Explicitly informing linters that we intended to avoid errors(errcheck)
+	_ = env.Set(clusterArch, v.k8sArch)
+	_ = env.Set(clusterVersion, v.k8sVersion)
 	v.nodeType, err = k8sapi.GetOSAndKernelVersion()
-	env.Set(nodeType, v.nodeType)
+	_ = env.Set(nodeType, v.nodeType)
 	if err != nil {
 		return err
 	}
 	v.openebsVersion = openebsversion.GetVersionDetails()
-	env.Set(openEBSversion, v.openebsVersion)
+	_ = env.Set(openEBSversion, v.openebsVersion)
 	return nil
 }
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR is required to make static analysis of the codebase and
it is achieved by adding lint tool in the codebase.

**What this PR does?**:
This PR adds [golangci-lint](https://golangci-lint.run/usage/configuration/) tool to verify linting issues in the codebase

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

- Currently, disabled `structcheck` analysis due to some [false-positive](https://github.com/golangci/golangci-lint/issues/537) errors and it can be enabled once the issue was resolved.
- Disabled linter on test directory as it contains repeated code(Need to fix it).


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>