### PR TITLE
feat(charts): set default fstype to ext4 in csi-provisioner

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 0.5.0
+version: 0.5.1
 appVersion: 0.5.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/templates/lvm-controller.yaml
+++ b/deploy/helm/charts/templates/lvm-controller.yaml
@@ -85,6 +85,7 @@ spec:
             - "--leader-election"
             - "--enable-capacity={{ .Values.storageCapacity }}"
             - "--extra-create-metadata=true"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -1182,6 +1182,7 @@ spec:
             - "--strict-topology"
             - "--leader-election"
             - "--extra-create-metadata=true"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/yamls/lvm-driver.yaml
+++ b/deploy/yamls/lvm-driver.yaml
@@ -789,6 +789,7 @@ spec:
             - "--strict-topology"
             - "--leader-election"
             - "--extra-create-metadata=true"
+            - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock


### PR DESCRIPTION
Set default fstype to ext4 in csi-provisioner. This will be helpful when fsType is not mention in storageclass.

