### PR TITLE
Add missing cas-type key for lvm under volume attributes

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -352,7 +352,7 @@ func (cs *controller) CreateVolume(
 		"lvm-localpv", analytics.VolumeProvision)
 
 	topology := map[string]string{lvm.LVMTopologyKey: vol.Spec.OwnerNodeID}
-	cntx := map[string]string{lvm.VolGroupKey: vol.Spec.VolGroup}
+	cntx := map[string]string{lvm.VolGroupKey: vol.Spec.VolGroup, lvm.OpenEBSCasTypeKey: lvm.LVMCasTypeName}
 
 	return csipayload.NewCreateVolumeResponseBuilder().
 		WithName(volName).

--- a/pkg/lvm/volume.go
+++ b/pkg/lvm/volume.go
@@ -53,6 +53,10 @@ const (
 	LVMStatusFailed string = "Failed"
 	// LVMStatusReady shows object has been processed
 	LVMStatusReady string = "Ready"
+	// OpenEBSCasTypeKey for the cas-type label
+	OpenEBSCasTypeKey string = "openebs.io/cas-type"
+	// LVMCasTypeName for the name of the cas-type
+	LVMCasTypeName string = "localpv-lvm"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: Abhinandan-Purkait <abhinandan.purkait@mayadata.io>

**Why is this PR required? What issue does it fix?**:
- LocalPV LVM currently doesnot have any cas-type label to indicate its cas-type.

**What this PR does?**:
- This PR adds the cas-type label to the volume attributes. 

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
