### PR TITLE
fix(create): wipe the filesystem signatures during LVM volume creation

### DIFF
--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -113,6 +113,9 @@ func buildLVMCreateArgs(vol *apis.LVMVolume) []string {
 	if strings.TrimSpace(vol.Spec.ThinProvision) != YES {
 		LVMVolArg = append(LVMVolArg, vol.Spec.VolGroup)
 	}
+
+	// -y is used to wipe the signatures before creating LVM volume
+	LVMVolArg = append(LVMVolArg, "-y")
 	return LVMVolArg
 }
 


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR is required to wipe existing filesystem signatures before creating LVM volume.


**What this PR does?**:
This PR wipes the filesystem signatures during LVM volume
creation time. "-y" option is used not to prompt for confirmation
interactively but always assume the answer yes(Answering yes will
wipe the previous filesystem signatures)

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:


Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>