### PR TITLE
feat(snapshot): add support for thin snapshot for lvm volumes

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -615,7 +615,7 @@ func (cs *controller) CreateSnapshot(
 
 	// the capacity of the snapshot will be set according to the params
 	// defined in the snapshot class
-	if snapSize != 0 {
+	if snapSize > 0 {
 		snapObj, err = snapbuilder.BuildFrom(snapObj).
 			WithSnapSize(strconv.FormatInt(snapSize, 10)).
 			Build()
@@ -657,7 +657,7 @@ func (cs *controller) CreateSnapshot(
 
 func getSnapSize(params *SnapshotParams, capacity int64) int64 {
 	var snapSize int64
-	if !params.AbsSnapSize && params.SnapSize != 0 {
+	if !params.AbsSnapSize {
 		snapSize = int64(float64(capacity) * (params.SnapSize / 100))
 	} else {
 		snapSize = int64(params.SnapSize)

--- a/pkg/driver/params.go
+++ b/pkg/driver/params.go
@@ -102,10 +102,8 @@ func NewVolumeParams(m map[string]string) (*VolumeParams, error) {
 // NewSnapshotParams parses the input params and instantiates new SnapshotParams.
 func NewSnapshotParams(m map[string]string) (*SnapshotParams, error) {
 	var err error
-	params := &SnapshotParams{ // set up defaults, if any.
-		SnapSize:    100,
-		AbsSnapSize: false,
-	}
+	params := &SnapshotParams{}
+
 	// parameter keys may be mistyped from the CRD specification when declaring
 	// the storageclass, which kubectl validation will not catch. Because
 	// parameter keys (not values!) are all lowercase, keys may safely be forced

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -330,14 +330,19 @@ func buildLVMSnapCreateArgs(snap *apis.LVMSnapshot) []string {
 		"--snapshot",
 		// name of snapshot
 		"--name", getLVMSnapName(snap.Name),
-		// size of the snapshot, will be same as source volume
-		"--size", size,
 		// set the permission to make the snapshot read-only. By default LVM snapshots are RW
 		"--permission", "r",
 		// volume to snapshot
 		volPath,
 	)
 
+	// When creating a thin snapshot volume, you do not specify the size of the volume.
+	// If you specify a size parameter, the snapshot that will be created will not
+	// be a thin snapshot volume and will not use the thin pool for storing data.
+	if len(snap.Spec.SnapSize) != 0 {
+		// size of the snapshot, will be same as source volume
+		LVMSnapArg = append(LVMSnapArg, "--size", size)
+	}
 	return LVMSnapArg
 }
 
@@ -376,7 +381,7 @@ func CreateSnapshot(snap *apis.LVMSnapshot) error {
 func DestroySnapshot(snap *apis.LVMSnapshot) error {
 	snapVolume := snap.Spec.VolGroup + "/" + getLVMSnapName(snap.Name)
 
-	ok, err := snapshotExists(snapVolume)
+	ok, err := isSnapshotExists(snap.Spec.VolGroup, getLVMSnapName(snap.Name))
 	if !ok {
 		klog.Infof("lvm: snapshot %s does not exist, skipping deletion", snapVolume)
 		return nil
@@ -518,17 +523,15 @@ func lvThinExists(vg string, name string) bool {
 	return name == strings.TrimSpace(string(out))
 }
 
-// snapshotExists checks if a snapshot volume exists given the name of the volume.
-// The name should be <vg-name>/<snapshot-name>
-func snapshotExists(snapVolumeName string) (bool, error) {
-	snapPath := DevPath + snapVolumeName
-	if _, err := os.Stat(snapPath); err != nil {
-		if os.IsNotExist(err) {
-			return false, nil
-		}
+// snapshotExists checks if a snapshot volume exists for the given volumegroup
+// and snapshot name.
+func isSnapshotExists(vg, snapVolumeName string) (bool, error) {
+	cmd := exec.Command("lvs", vg+"/"+snapVolumeName, "--noheadings", "-o", "lv_name")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
 		return false, err
 	}
-	return true, nil
+	return snapVolumeName == strings.TrimSpace(string(out)), nil
 }
 
 // getVGSize get the size in bytes for given volumegroup name

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -340,7 +340,7 @@ func buildLVMSnapCreateArgs(snap *apis.LVMSnapshot) []string {
 	// If you specify a size parameter, the snapshot that will be created will not
 	// be a thin snapshot volume and will not use the thin pool for storing data.
 	if len(snap.Spec.SnapSize) != 0 {
-		// size of the snapshot, will be same as source volume
+		// size of the snapshot, will be same or less than source volume
 		LVMSnapArg = append(LVMSnapArg, "--size", size)
 	}
 	return LVMSnapArg


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

## Pull Request template

**Why is this PR required? What issue does it fix?**:
To support thin snapshot for lvm volumes

**What this PR does?**:
Add support for thin snapshot for lvm volumes based on the SnapSize configured in SnapshotClass.


So there are two scenarios here :

**1. Snapshot class `snapsize` parameter.**
 
In this case whether volume is thin provisioned or thick provisioned, we should create a thick snapshot with size as `snapsize` mentioned in the snapshotclass.

```
kind: VolumeSnapshotClass
apiVersion: snapshot.storage.k8s.io/v1
metadata:
  name: lvmpv-snapclass
  annotations:
    snapshot.storage.kubernetes.io/is-default-class: "true"
parameters:
  snapsize: 1Gi
driver: local.csi.openebs.io
deletionPolicy: Delete
```
```bash
 $ sudo lvs
  LV                                       VG    Attr       LSize Pool           Origin                                   Data%  Meta%  Move Log Cpy%Sync Convert
  7ba91701-8663-47a9-898e-40970ca137b8     lvmvg sri-a-s--- 1.00g                pvc-699c1ee1-c0c0-4bb1-a353-f63e8be5f190 0.01                                   
  c1c4264f-2216-4e33-9145-dbf7a357d4b5     lvmvg sri-a-s--- 1.00g                pvc-c367aad2-885f-4eb1-82b4-17df56285a8f 0.01                                   
  lvmvg_thinpool                           lvmvg twi-aotz-- 2.00g                                                         4.76   12.30                           
  pvc-699c1ee1-c0c0-4bb1-a353-f63e8be5f190 lvmvg owi-aos--- 4.00g                                                                                                
  pvc-c367aad2-885f-4eb1-82b4-17df56285a8f lvmvg owi-aotz-- 2.00g lvmvg_thinpool                                          4.76                                   


```


**2. Snapshot class does not have `snapsize` parameter**
In this case, for thin volumes, we should create a thin snapshot and for thick volume, we should create a thick snapshot. 
While creating the thick snapshot for thick volumes, since snapsize parameter is not provided, driver should reserve size equal to the volume for snapshots.

```yaml
kind: VolumeSnapshotClass
apiVersion: snapshot.storage.k8s.io/v1
metadata:
  name: lvmpv-snapclass
  annotations:
    snapshot.storage.kubernetes.io/is-default-class: "true"
driver: local.csi.openebs.io
deletionPolicy: Delete
```

```
$ sudo lvs
  LV                                       VG    Attr       LSize Pool           Origin                                   Data%  Meta%  Move Log Cpy%Sync Convert
  c6a3e548-8614-4c9f-86a3-774de6eaaa73     lvmvg Vri---tz-k 2.00g lvmvg_thinpool pvc-c367aad2-885f-4eb1-82b4-17df56285a8f                                        
  f2e18137-1aa2-4302-a562-17ba9f088bc4     lvmvg sri-a-s--- 4.00g                pvc-699c1ee1-c0c0-4bb1-a353-f63e8be5f190 0.01                                   
  lvmvg_thinpool                           lvmvg twi-aotz-- 2.00g                                                         4.77   12.50                           
  pvc-699c1ee1-c0c0-4bb1-a353-f63e8be5f190 lvmvg owi-aos--- 4.00g                                                                                                
  pvc-c367aad2-885f-4eb1-82b4-17df56285a8f lvmvg Vwi-aotz-- 2.00g lvmvg_thinpool                                          4.76                                   


```

**Does this PR require any upgrade changes?**:
No

**Checklist:**
- [x] Fixes #98 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

