### PR TITLE
fix(helm): Pass listen-address flag through arguments and install service.

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -45,7 +45,7 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
         with:
           config: buildscripts/kind_config.yaml

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 0.6.1
+version: 0.6.2
 appVersion: 0.6.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the OpenEBS LVM Localpv
 | `lvmPlugin.image.repository`| Image repository for openebs-lvm-plugin| `openebs/lvm-driver`|
 | `lvmPlugin.image.pullPolicy`| Image pull policy for openebs-lvm-plugin| `IfNotPresent`|
 | `lvmPlugin.image.tag`| Image tag for openebs-lvm-plugin| `0.6.0`|
-| `lvmPlugin.metricsPort`| Port number used for exposing lvm-metrics | `9500`|
+| `lvmPlugin.metricsPort`| The TCP port number used for exposing lvm-metrics | `9500`|
 | `lvmNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `k8s.gcr.io/`|
 | `lvmNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|
 | `lvmNode.driverRegistrar.image.pullPolicy`| Image pull policy for csi-node-driver-registrar| `IfNotPresent`|

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the OpenEBS LVM Localpv
 | `lvmPlugin.image.repository`| Image repository for openebs-lvm-plugin| `openebs/lvm-driver`|
 | `lvmPlugin.image.pullPolicy`| Image pull policy for openebs-lvm-plugin| `IfNotPresent`|
 | `lvmPlugin.image.tag`| Image tag for openebs-lvm-plugin| `0.6.0`|
-| `lvmPlugin.metricsListenAddress`| The TCP network address where the prometheus metrics endpoint will listen | `9080`|
+| `lvmPlugin.metricsListenAddress`| The TCP network address where the prometheus metrics endpoint will listen | `9500`|
 | `lvmNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `k8s.gcr.io/`|
 | `lvmNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|
 | `lvmNode.driverRegistrar.image.pullPolicy`| Image pull policy for csi-node-driver-registrar| `IfNotPresent`|

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -79,6 +79,7 @@ The following table lists the configurable parameters of the OpenEBS LVM Localpv
 | `lvmPlugin.image.repository`| Image repository for openebs-lvm-plugin| `openebs/lvm-driver`|
 | `lvmPlugin.image.pullPolicy`| Image pull policy for openebs-lvm-plugin| `IfNotPresent`|
 | `lvmPlugin.image.tag`| Image tag for openebs-lvm-plugin| `0.6.0`|
+| `lvmPlugin.metricsListenAddress`| The TCP network address where the prometheus metrics endpoint will listen | `9080`|
 | `lvmNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `k8s.gcr.io/`|
 | `lvmNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|
 | `lvmNode.driverRegistrar.image.pullPolicy`| Image pull policy for csi-node-driver-registrar| `IfNotPresent`|

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -79,7 +79,7 @@ The following table lists the configurable parameters of the OpenEBS LVM Localpv
 | `lvmPlugin.image.repository`| Image repository for openebs-lvm-plugin| `openebs/lvm-driver`|
 | `lvmPlugin.image.pullPolicy`| Image pull policy for openebs-lvm-plugin| `IfNotPresent`|
 | `lvmPlugin.image.tag`| Image tag for openebs-lvm-plugin| `0.6.0`|
-| `lvmPlugin.metricsListenAddress`| The TCP network address where the prometheus metrics endpoint will listen | `9500`|
+| `lvmPlugin.metricsPort`| Port number used for exposing lvm-metrics | `9500`|
 | `lvmNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `k8s.gcr.io/`|
 | `lvmNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|
 | `lvmNode.driverRegistrar.image.pullPolicy`| Image pull policy for csi-node-driver-registrar| `IfNotPresent`|

--- a/deploy/helm/charts/templates/lvm-node-service.yaml
+++ b/deploy/helm/charts/templates/lvm-node-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.lvmPlugin.metricsListenAddress }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "lvmlocalpv.fullname" . }}-node-service
+  labels:
+    {{- include "lvmlocalpv.lvmNode.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: metrics
+      port: {{ .Values.lvmPlugin.metricsListenAddress }}
+      targetPort: {{ .Values.lvmPlugin.metricsListenAddress }}
+  selector:
+    {{- with .Values.lvmNode.podLabels }}
+    {{ toYaml . }}
+    {{- end }}
+  type: ClusterIP
+{{- end }}

--- a/deploy/helm/charts/templates/lvm-node-service.yaml
+++ b/deploy/helm/charts/templates/lvm-node-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.lvmPlugin.metricsListenAddress }}
+{{- if .Values.lvmPlugin.metricsPort }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -9,8 +9,8 @@ spec:
   clusterIP: None
   ports:
     - name: metrics
-      port: {{ .Values.lvmPlugin.metricsListenAddress }}
-      targetPort: {{ .Values.lvmPlugin.metricsListenAddress }}
+      port: {{ .Values.lvmPlugin.metricsPort }}
+      targetPort: {{ .Values.lvmPlugin.metricsPort }}
   selector:
     {{- with .Values.lvmNode.podLabels }}
     {{ toYaml . }}

--- a/deploy/helm/charts/templates/lvm-node-service.yaml
+++ b/deploy/helm/charts/templates/lvm-node-service.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "lvmlocalpv.lvmNode.labels" . | nindent 4 }}
 spec:
+  clusterIP: None
   ports:
     - name: metrics
       port: {{ .Values.lvmPlugin.metricsListenAddress }}
@@ -14,5 +15,4 @@ spec:
     {{- with .Values.lvmNode.podLabels }}
     {{ toYaml . }}
     {{- end }}
-  type: ClusterIP
 {{- end }}

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -75,7 +75,7 @@ spec:
             - "--riops-per-gb=$(RIOPS_PER_GB)"
             - "--wiops-per-gb=$(WIOPS_PER_GB)"
             {{- end }}
-            {{- if .Values.lvmNode.metricsListenAddress }}
+            {{- if .Values.lvmPlugin.metricsListenAddress }}
             - "--listenAddress=$(METRICS_LISTEN_ADDRESS)"
             {{- end }}
           env:
@@ -99,9 +99,9 @@ spec:
             - name: WIOPS_PER_GB
               value: {{ .Values.lvmPlugin.ioLimits.writeIopsPerGB }}
             {{- end }}
-            {{- if .Values.lvmNode.metricsListenAddress }}
+            {{- if .Values.lvmPlugin.metricsListenAddress }}
             - name: METRICS_LISTEN_ADDRESS
-              value: {{ .Values.lvmNode.metricsListenAddress }}
+              value: :{{ .Values.lvmPlugin.metricsListenAddress }}
             {{- end }}
           volumeMounts:
             - name: plugin-dir

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -75,6 +75,9 @@ spec:
             - "--riops-per-gb=$(RIOPS_PER_GB)"
             - "--wiops-per-gb=$(WIOPS_PER_GB)"
             {{- end }}
+            {{- if .Values.lvmNode.metricsListenAddress }}
+            - "--listenAddress=$(METRICS_LISTEN_ADDRESS)"
+            {{- end }}
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:
@@ -95,6 +98,10 @@ spec:
               value: {{ .Values.lvmPlugin.ioLimits.readIopsPerGB }}
             - name: WIOPS_PER_GB
               value: {{ .Values.lvmPlugin.ioLimits.writeIopsPerGB }}
+            {{- end }}
+            {{- if .Values.lvmNode.metricsListenAddress }}
+            - name: METRICS_LISTEN_ADDRESS
+              value: {{ .Values.lvmNode.metricsListenAddress }}
             {{- end }}
           volumeMounts:
             - name: plugin-dir

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -76,7 +76,7 @@ spec:
             - "--wiops-per-gb=$(WIOPS_PER_GB)"
             {{- end }}
             {{- if .Values.lvmPlugin.metricsListenAddress }}
-            - "--listenAddress=$(METRICS_LISTEN_ADDRESS)"
+            - "--listen-address=$(METRICS_LISTEN_ADDRESS)"
             {{- end }}
           env:
             - name: OPENEBS_NODE_ID

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -75,7 +75,7 @@ spec:
             - "--riops-per-gb=$(RIOPS_PER_GB)"
             - "--wiops-per-gb=$(WIOPS_PER_GB)"
             {{- end }}
-            {{- if .Values.lvmPlugin.metricsListenAddress }}
+            {{- if .Values.lvmPlugin.metricsPort }}
             - "--listen-address=$(METRICS_LISTEN_ADDRESS)"
             {{- end }}
           env:
@@ -99,9 +99,9 @@ spec:
             - name: WIOPS_PER_GB
               value: {{ .Values.lvmPlugin.ioLimits.writeIopsPerGB }}
             {{- end }}
-            {{- if .Values.lvmPlugin.metricsListenAddress }}
+            {{- if .Values.lvmPlugin.metricsPort }}
             - name: METRICS_LISTEN_ADDRESS
-              value: :{{ .Values.lvmPlugin.metricsListenAddress }}
+              value: :{{ .Values.lvmPlugin.metricsPort }}
             {{- end }}
           volumeMounts:
             - name: plugin-dir

--- a/deploy/helm/charts/templates/service.yaml
+++ b/deploy/helm/charts/templates/service.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.lvmNode.metricsListenAddress }}
+apiVersion: v1
+kind: Service
+metadata:
+
+{{- end }}

--- a/deploy/helm/charts/templates/service.yaml
+++ b/deploy/helm/charts/templates/service.yaml
@@ -1,6 +1,0 @@
-{{- if .Values.lvmNode.metricsListenAddress }}
-apiVersion: v1
-kind: Service
-metadata:
-
-{{- end }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -134,7 +134,7 @@ lvmPlugin:
     writeIopsPerGB: ""
   # The TCP network address where the prometheus metrics endpoint will listen.
   # The default is empty string, which means metrics endpoint is disabled.
-  # If not set, service will not be created to expose this endpoint to serviceMonitor.
+  # If not set, service will not be created to expose this endpoint to serviceMonitor and listen-address flag will not be set.
   metricsListenAddress: 9080
 
 role: openebs-lvm

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -132,10 +132,9 @@ lvmPlugin:
     containerRuntime: containerd
     readIopsPerGB: ""
     writeIopsPerGB: ""
-  # The TCP network address where the prometheus metrics endpoint will listen.
-  # The default is empty string, which means metrics endpoint is disabled.
-  # If not set, service will not be created to expose this endpoint to serviceMonitor and listen-address flag will not be set.
-  metricsListenAddress: 9500
+  # Port number used for exposing lvm-metrics.
+  # If not set, service will not be created to expose metrics endpoint to serviceMonitor and listen-address flag will not be set.
+  metricsPort: 9500
 
 role: openebs-lvm
 

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -36,7 +36,6 @@ lvmNode:
   # This can be configured to run on various different k8s distributions like
   # microk8s where kubelet dir is different
   kubeletDir: "/var/lib/kubelet/"
-  metricsListenAddress: :9080
   resources: {}
 #    limits:
 #      cpu: 10m
@@ -133,6 +132,10 @@ lvmPlugin:
     containerRuntime: containerd
     readIopsPerGB: ""
     writeIopsPerGB: ""
+  # The TCP network address where the prometheus metrics endpoint will listen.
+  # The default is empty string, which means metrics endpoint is disabled.
+  # If not set, service will not be created to expose this endpoint to serviceMonitor.
+  metricsListenAddress: 9080
 
 role: openebs-lvm
 

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -135,7 +135,7 @@ lvmPlugin:
   # The TCP network address where the prometheus metrics endpoint will listen.
   # The default is empty string, which means metrics endpoint is disabled.
   # If not set, service will not be created to expose this endpoint to serviceMonitor and listen-address flag will not be set.
-  metricsListenAddress: 9080
+  metricsListenAddress: 9500
 
 role: openebs-lvm
 

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -132,7 +132,7 @@ lvmPlugin:
     containerRuntime: containerd
     readIopsPerGB: ""
     writeIopsPerGB: ""
-  # Port number used for exposing lvm-metrics.
+  # The TCP port number used for exposing lvm-metrics.
   # If not set, service will not be created to expose metrics endpoint to serviceMonitor and listen-address flag will not be set.
   metricsPort: 9500
 

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -36,6 +36,7 @@ lvmNode:
   # This can be configured to run on various different k8s distributions like
   # microk8s where kubelet dir is different
   kubeletDir: "/var/lib/kubelet/"
+  metricsListenAddress: :9080
   resources: {}
 #    limits:
 #      cpu: 10m

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -1357,6 +1357,7 @@ spec:
             - "--nodeid=$(OPENEBS_NODE_ID)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
+            - "--listen-address=$(METRICS_LISTEN_ADDRESS)"
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:
@@ -1368,6 +1369,8 @@ spec:
               value: agent
             - name: LVM_NAMESPACE
               value: openebs
+            - name: METRICS_LISTEN_ADDRESS
+              value: :9500
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin
@@ -1396,3 +1399,18 @@ spec:
             path: /var/lib/kubelet/
             type: Directory
 ---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-lvm-node-service
+  labels:
+    name: openebs-lvm-node
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9500
+      targetPort: 9500
+  selector:
+    app: openebs-lvm-node

--- a/deploy/yamls/lvm-driver.yaml
+++ b/deploy/yamls/lvm-driver.yaml
@@ -988,6 +988,7 @@ spec:
             - "--nodeid=$(OPENEBS_NODE_ID)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
+            - "--listen-address=$(METRICS_LISTEN_ADDRESS)"
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:
@@ -999,6 +1000,8 @@ spec:
               value: agent
             - name: LVM_NAMESPACE
               value: openebs
+            - name: METRICS_LISTEN_ADDRESS
+              value: :9500
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin
@@ -1027,3 +1030,18 @@ spec:
             path: /var/lib/kubelet/
             type: Directory
 ---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: openebs-lvm-node-service
+  labels:
+    name: openebs-lvm-node
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9500
+      targetPort: 9500
+  selector:
+    app: openebs-lvm-node


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**

- Pass `listen-address` flag value through arguments.
- This PR is also required for **Service Discovery** in Prometheus.
  ![Screenshot from 2021-06-23 10-00-59](https://user-images.githubusercontent.com/32039199/123620245-9fb9a500-d827-11eb-8bf5-d07c2b51d60e.png)
- To get LVM metrics in Prometheus:
`Metrics Endpoint <- Service <- ServiceMonitor -> Prometheus`
- Add configuration for service yaml which needs to be installed when lvm-metrics collection is enabled.


**What this PR does?**:

- LVM metrics endpoint is passed via arguments to openebs-lvm-plugin.
- This PR also adds service yaml while installing lvm-localPV via helm chart.
- Configuration in values.yaml:
  ```
  lvmPlugin:
    ...
    metricsPort: 9500
    ...
  ```
- If **metricsPort** is set, then this value is passed through the environment variable to openebs-lvm-plugin which is used in the code as an endpoint to expose LVM metrics and also service is installed.

**Does this PR require any upgrade changes?**:

- This PR will create a new helm release. Helm chart version is bumped in this PR.

**Any additional information for your reviewer?** :
- Dependent PR: https://github.com/openebs/lvm-localpv/pull/94


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
