### PR TITLE
refact(e2e): refactor the custom-topology e2e-test

### DIFF
--- a/e2e-tests/experiments/functional/lvmpv-custom-topology/test.yml
+++ b/e2e-tests/experiments/functional/lvmpv-custom-topology/test.yml
@@ -163,7 +163,8 @@
           register: status
           failed_when: "status.rc != 0"
 
-        ## Restart of node-agent pods is required to get aware of node_labels
+        ## We have to edit the node-daemonset with the required keys, so that csinode
+        ## can take that key under ALLOWED_TOPOLOGIES.
         ## Meanwhile PVC will be remain in pending state.
 
         - name: Check all the pvc is in pending state.
@@ -173,10 +174,12 @@
           register: pvc_status
           failed_when: "pvc_status.stdout != 'Pending'"
 
-        - name: Restart the lvm csi node-agent daemonset pods in kube-system namespace
-          shell: kubectl delete pods -n kube-system -l app=openebs-lvm-node
+        - name: Set the ALLOWED_TOPOLOGIES env in lvm node-daemonset with test-specific topology key
+          shell: kubectl set env daemonset/openebs-lvm-node -n kube-system ALLOWED_TOPOLOGIES=kubernetes.io/hostname,{{ lkey }}
           args: 
             executable: /bin/bash
+          register: topology_status
+          failed_when: "topology_status.rc != 0"
 
         - name: Wait for 10 sec
           shell:


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

- This PR refactors the custom-topology e2e-test with respect to the latest changes done in this PR https://github.com/openebs/lvm-localpv/pull/110
- Now we have to set the ALLOWED_TOPOLOGIES in the daemonset spec env's in openebs-lvm-plugin container,

```
env:
  - name: OPENEBS_NODE_ID
    valueFrom:
      fieldRef:
        fieldPath: spec.nodeName
  - name: OPENEBS_CSI_ENDPOINT
    value: unix:///plugin/csi.sock
  - name: OPENEBS_NODE_DRIVER
    value: agent
  - name: LVM_NAMESPACE
    value: openebs
  - name: ALLOWED_TOPOLOGIES
    value: "openebs.io/rack"
    ```