### PR TITLE
[stable/lvm]: add allowed topologies env in node daemonset

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.7.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -102,6 +102,7 @@ helm install openebs-lvmlocalpv openebs-lvmlocalpv/lvm-localpv --namespace opene
 | `lvmPlugin.image.pullPolicy`| Image pull policy for openebs-lvm-plugin| `IfNotPresent`|
 | `lvmPlugin.image.tag`| Image tag for openebs-lvm-plugin| `0.7.0`|
 | `lvmPlugin.metricsPort`| The TCP port number used for exposing lvm-metrics | `9500`|
+| `lvmPlugin.allowedTopologies`| The comma seperated list of allowed node topologies | `kubernetes.io/hostname,`|
 | `lvmNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `k8s.gcr.io/`|
 | `lvmNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|
 | `lvmNode.driverRegistrar.image.pullPolicy`| Image pull policy for csi-node-driver-registrar| `IfNotPresent`|

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -103,6 +103,10 @@ spec:
             - name: METRICS_LISTEN_ADDRESS
               value: :{{ .Values.lvmPlugin.metricsPort }}
             {{- end }}
+            {{- if .Values.lvmPlugin.allowedTopologies }}
+            - name: ALLOWED_TOPOLOGIES
+              value: {{ .Values.lvmPlugin.allowedTopologies }}
+            {{- end }}
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -135,6 +135,8 @@ lvmPlugin:
   # The TCP port number used for exposing lvm-metrics.
   # If not set, service will not be created to expose metrics endpoint to serviceMonitor and listen-address flag will not be set.
   metricsPort: 9500
+  # Comma seperated list of k8s worker node topologies
+  allowedTopologies: "kubernetes.io/hostname,"
 
 role: openebs-lvm
 


### PR DESCRIPTION
Signed-off-by: prateekpandey14 <prateekpandey14@gmail.com>

## Pull Request template

**What this PR does?**:

Add allowed topologies ENV in node daemonset template

```
$  helm install openebs --dry-run --namespace openebs .
```
```yaml
          env:
            - name: OPENEBS_NODE_ID
              valueFrom:
                fieldRef:
                  fieldPath: spec.nodeName
            - name: OPENEBS_CSI_ENDPOINT
              value: unix:///plugin/csi.sock
            - name: OPENEBS_NODE_DRIVER
              value: agent
            - name: LVM_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
            - name: METRICS_LISTEN_ADDRESS
              value: :9500
            - name: ALLOWED_TOPOLOGIES
              value: kubernetes.io/hostname,


```