### PR TITLE
Update(deploy): Update the k8s csi sidecar versions

### DIFF
--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -446,6 +446,8 @@ spec:
   # do not require volumeattachment
   attachRequired: false
   podInfoOnMount: true
+  storageCapacity: true
+
 ---
 
 apiVersion: apiextensions.k8s.io/v1
@@ -1196,7 +1198,7 @@ spec:
       serviceAccount: openebs-lvm-controller-sa
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -1227,7 +1229,7 @@ spec:
             - "--leader-election=true"
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -1236,10 +1238,19 @@ spec:
             - "--strict-topology"
             - "--leader-election"
             - "--extra-create-metadata=true"
+            - "--enable-capacity=true"
             - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -1410,7 +1421,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/deploy/yamls/lvm-driver.yaml
+++ b/deploy/yamls/lvm-driver.yaml
@@ -10,6 +10,8 @@ spec:
   # do not require volumeattachment
   attachRequired: false
   podInfoOnMount: true
+  storageCapacity: true
+
 ---
 
 apiVersion: apiextensions.k8s.io/v1
@@ -762,7 +764,7 @@ spec:
       serviceAccount: openebs-lvm-controller-sa
       containers:
         - name: csi-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.1.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -793,7 +795,7 @@ spec:
             - "--leader-election=true"
           imagePullPolicy: IfNotPresent
         - name: csi-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -802,10 +804,19 @@ spec:
             - "--strict-topology"
             - "--leader-election"
             - "--extra-create-metadata=true"
+            - "--enable-capacity=true"
             - "--default-fstype=ext4"
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
@@ -976,7 +987,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/upgrade/README.md
+++ b/upgrade/README.md
@@ -75,3 +75,15 @@ spec:
 ```
 
 4. Now we can apply the lvm-operator.yaml file to upgrade lvm-driver to 0.7.0 version.
+
+### *Note*
+
+While upgrading lvm-driver from v0.8.0 to later version by applying lvm-operator file, we may get this error.
+```
+The CSIDriver "local.csi.openebs.io" is invalid: spec.storageCapacity: Invalid value: true: field is immutable
+```
+It occurs due to newly added field `storageCapacity: true` in csi driver spec. In that case, first delete the csi-driver by running this command:
+```
+$ kubectl delete csidriver local.csi.openebs.io 
+```
+Now we can again apply the operator yaml file.


### PR DESCRIPTION
Signed-off-by: w3aman <aman.gupta@mayadata.io>

Update the CSI driver sidecars version as below:

- CSI Provisioner: 
k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0

- CSI Resizer:
k8s.gcr.io/sig-storage/csi-resizer:v1.2.0

- CSI Node Driver Registrar
k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
