### PR TITLE
chore(provision): cleannup the volume at the provisioning time

### DIFF
--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -286,6 +286,11 @@ func CreateVolume(vol *apis.LVMVolume) error {
 	}
 	klog.Infof("lvm: created volume %s", volume)
 
+	err = removeVolumeFilesystem(vol)
+	if err != nil {
+		klog.Infof("lvm: volume %s filesystem cleanup failed", volume)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
fixes : https://github.com/openebs/lvm-localpv/issues/135

Cleanup the volume while provisioing it. If disk already had some partitions before and volume landed at the same offset we should clean it at the creation time. We already do the same at the deletion time.
