### PR TITLE
fix(endpoints-discovery): Fixed lvm-node svc endpoints discovery

### DIFF
--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -1495,9 +1495,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: openebs-lvm-node-service
+  namespace: kube-system
   labels:
     name: openebs-lvm-node
-  namespace: kube-system
 spec:
   clusterIP: None
   ports:

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -1497,6 +1497,7 @@ metadata:
   name: openebs-lvm-node-service
   labels:
     name: openebs-lvm-node
+  namespace: kube-system
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/lvm-driver.yaml
+++ b/deploy/yamls/lvm-driver.yaml
@@ -1063,6 +1063,7 @@ metadata:
   name: openebs-lvm-node-service
   labels:
     name: openebs-lvm-node
+  namespace: kube-system
 spec:
   clusterIP: None
   ports:

--- a/deploy/yamls/lvm-driver.yaml
+++ b/deploy/yamls/lvm-driver.yaml
@@ -1061,9 +1061,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: openebs-lvm-node-service
+  namespace: kube-system
   labels:
     name: openebs-lvm-node
-  namespace: kube-system
 spec:
   clusterIP: None
   ports:


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The lvm-node service were not be to discover/identify the endpoints because of being installed in different ns  then the lvm node daemonset through operator.

**What this PR does?**:
This PR adds namespace field in the metadata section to the service same as the namespace in which the lvm-node/lvm-driver daemonset is installed to that the service is able to successfully identify its endpoints.

**Does this PR require any upgrade changes?**:
No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: