### PR TITLE
chore(CSI Images): Update helm k8s csi sidecar versions

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 0.8.1
+version: 0.8.2
 appVersion: 0.8.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -106,7 +106,7 @@ helm install openebs-lvmlocalpv openebs-lvmlocalpv/lvm-localpv --namespace opene
 | `lvmNode.driverRegistrar.image.registry`| Registry for csi-node-driver-registrar image| `k8s.gcr.io/`|
 | `lvmNode.driverRegistrar.image.repository`| Image repository for csi-node-driver-registrar| `sig-storage/csi-node-driver-registrar`|
 | `lvmNode.driverRegistrar.image.pullPolicy`| Image pull policy for csi-node-driver-registrar| `IfNotPresent`|
-| `lvmNode.driverRegistrar.image.tag`| Image tag for csi-node-driver-registrar| `v1.2.0`|
+| `lvmNode.driverRegistrar.image.tag`| Image tag for csi-node-driver-registrar| `v2.3.0`|
 | `lvmNode.updateStrategy.type`| Update strategy for lvmnode daemonset | `RollingUpdate` |
 | `lvmNode.kubeletDir`| Kubelet mount point for lvmnode daemonset| `"/var/lib/kubelet/"` |
 | `lvmNode.annotations` | Annotations for lvmnode daemonset metadata| `""`|
@@ -120,7 +120,7 @@ helm install openebs-lvmlocalpv openebs-lvmlocalpv/lvm-localpv --namespace opene
 | `lvmController.resizer.image.registry`| Registry for csi-resizer image| `k8s.gcr.io/`|
 | `lvmController.resizer.image.repository`| Image repository for csi-resizer| `sig-storage/csi-resizer`|
 | `lvmController.resizer.image.pullPolicy`| Image pull policy for csi-resizer| `IfNotPresent`|
-| `lvmController.resizer.image.tag`| Image tag for csi-resizer| `v1.1.0`|
+| `lvmController.resizer.image.tag`| Image tag for csi-resizer| `v1.2.0`|
 | `lvmController.snapshotter.image.registry`| Registry for csi-snapshotter image| `k8s.gcr.io/`|
 | `lvmController.snapshotter.image.repository`| Image repository for csi-snapshotter| `sig-storage/csi-snapshotter`|
 | `lvmController.snapshotter.image.pullPolicy`| Image pull policy for csi-snapshotter| `IfNotPresent`|
@@ -132,7 +132,7 @@ helm install openebs-lvmlocalpv openebs-lvmlocalpv/lvm-localpv --namespace opene
 | `lvmController.provisioner.image.registry`| Registry for csi-provisioner image| `k8s.gcr.io/`|
 | `lvmController.provisioner.image.repository`| Image repository for csi-provisioner| `sig-storage/csi-provisioner`|
 | `lvmController.provisioner.image.pullPolicy`| Image pull policy for csi-provisioner| `IfNotPresent`|
-| `lvmController.provisioner.image.tag`| Image tag for csi-provisioner| `v2.1.0`|
+| `lvmController.provisioner.image.tag`| Image tag for csi-provisioner| `v2.3.0`|
 | `lvmController.updateStrategy.type`| Update strategy for lvm localpv controller statefulset | `RollingUpdate` |
 | `lvmController.annotations` | Annotations for lvm localpv controller statefulset metadata| `""`|
 | `lvmController.podAnnotations`| Annotations for lvm localpv controller statefulset's pods metadata | `""`|

--- a/deploy/helm/charts/templates/lvm-controller.yaml
+++ b/deploy/helm/charts/templates/lvm-controller.yaml
@@ -91,7 +91,7 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: POD_NAMESPACE
+            - name: NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -28,7 +28,7 @@ lvmNode:
       repository: sig-storage/csi-node-driver-registrar
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: v2.1.0
+      tag: v2.3.0
   updateStrategy:
     type: RollingUpdate
   annotations: {}
@@ -69,7 +69,7 @@ lvmController:
       repository: sig-storage/csi-resizer
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: v1.1.0
+      tag: v1.2.0
   snapshotter:
     name: "csi-snapshotter"
     image:
@@ -99,7 +99,7 @@ lvmController:
       repository: sig-storage/csi-provisioner
       pullPolicy: IfNotPresent
       # Overrides the image tag whose default is the chart appVersion.
-      tag: v2.1.0
+      tag: v3.0.0
   updateStrategy:
     type: RollingUpdate
   annotations: {}


### PR DESCRIPTION



**Why is this PR required? What issue does it fix?**:
This PR updates the K8s sidecar images in helm installation
Please refer to #137 

**What this PR does?**:
This PR does the following changes:

- Update the CSI driver sidecars version as below:

    CSI Provisioner:
    k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0

    CSI Resizer:
    k8s.gcr.io/sig-storage/csi-resizer:v1.2.0

    CSI Node Driver Registrar
    k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0


**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Yes, by provisioning volume with changes.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>