### PR TITLE
feat(helm): Disable leader-elections if replicas=1, make logLevel configurable

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 0.8.2
+version: 0.8.3
 appVersion: 0.8.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/templates/lvm-controller.yaml
+++ b/deploy/helm/charts/templates/lvm-controller.yaml
@@ -42,9 +42,11 @@ spec:
         - name: {{ .Values.lvmController.resizer.name }}
           image: "{{ .Values.lvmController.resizer.image.registry }}{{ .Values.lvmController.resizer.image.repository }}:{{ .Values.lvmController.resizer.image.tag }}"
           args:
-            - "--v=5"
+            - "--v={{ .Values.lvmController.logLevel }}"
             - "--csi-address=$(ADDRESS)"
+            {{- if gt (int .Values.lvmController.replicas) 1 }}
             - "--leader-election"
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -59,7 +61,9 @@ spec:
           imagePullPolicy: {{ .Values.lvmController.snapshotter.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
+            {{- if gt (int .Values.lvmController.replicas) 1 }}
             - "--leader-election"
+            {{- end }}
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
@@ -71,8 +75,10 @@ spec:
         - name: {{ .Values.lvmController.snapshotController.name }}
           image: "{{ .Values.lvmController.snapshotController.image.registry }}{{ .Values.lvmController.snapshotController.image.repository }}:{{ .Values.lvmController.snapshotController.image.tag }}"
           args:
-            - "--v=5"
+            - "--v={{ .Values.lvmController.logLevel }}"
+            {{- if gt (int .Values.lvmController.replicas) 1 }}
             - "--leader-election=true"
+            {{- end }}
           imagePullPolicy: {{ .Values.lvmController.snapshotController.image.pullPolicy }}
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
@@ -81,10 +87,12 @@ spec:
           imagePullPolicy: {{ .Values.lvmController.provisioner.image.pullPolicy }}
           args:
             - "--csi-address=$(ADDRESS)"
-            - "--v=5"
+            - "--v={{ .Values.lvmController.logLevel }}"
             - "--feature-gates=Topology=true"
             - "--strict-topology"
+            {{- if gt (int .Values.lvmController.replicas) 1 }}
             - "--leader-election"
+            {{- end }}
             - "--enable-capacity={{ .Values.storageCapacity }}"
             - "--extra-create-metadata=true"
             - "--default-fstype=ext4"

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -36,7 +36,7 @@ spec:
           image: "{{ .Values.lvmNode.driverRegistrar.image.registry }}{{ .Values.lvmNode.driverRegistrar.image.repository }}:{{ .Values.lvmNode.driverRegistrar.image.tag }}"
           imagePullPolicy: {{ .Values.lvmNode.driverRegistrar.image.pullPolicy }}
           args:
-            - "--v=5"
+            - "--v={{ .Values.lvmNode.logLevel }}"
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
           lifecycle:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -52,6 +52,7 @@ lvmNode:
   priorityClass:
     create: true
     name: lvm-localpv-csi-node-critical
+  logLevel: 5
 
 
 # lvmController contains the configurables for
@@ -60,6 +61,7 @@ lvmController:
   componentName: openebs-lvm-controller
   replicas: 1
   serviceName: openebs-lvm
+  logLevel: 5
   resizer:
     name: "csi-resizer"
     image:


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
- allows to optionally reduce log noise
- reduces load on controllers / etcd for single replica deployments

**What this PR does?**:
Disable leader-election for the controllers if replicas = 1

**Does this PR require any upgrade changes?**:
No.
