### PR TITLE
fix(lvm-node): update the lvm-node podlabels

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 0.8.4
+version: 0.8.5
 appVersion: 0.8.2
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: http://www.openebs.io/

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -44,7 +44,8 @@ lvmNode:
 #      cpu: 10m
 #      memory: 32Mi
   ## Labels to be added to openebs-lvm node pods
-  podLabels: {}
+  podLabels:
+    app: openebs-lvm-node
   nodeSelector: {}
   tolerations: []
   securityContext: {}


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**Why is this PR required? What issue does it fix?**:
The lvm-node service selector field in helm template points to podLabels value which is empty by default. Hence when lvm-localpv is deployed using helm the lvm-node-service endpoints remain empty as the service's selector field is empty and not able to indetify any targets. With this issue, when monitoring is enabled for lvm, the servicemonitors are not able to identify its targets and therefore metrics scrapping doesn't occur.

**What this PR does?**:
This PR adds podLabels value in values.yaml so that when lvm is installed via helm, the service selector field does not remain empty and endpoints are discovered.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
