### PR TITLE
docs(snapshot): document dm-snapshot kernel module is required.

### DIFF
--- a/docs/snapshot.md
+++ b/docs/snapshot.md
@@ -1,6 +1,6 @@
 ## Snapshot
 
-The LVM driver supports creating snapshots of the LVM volumes. Certain settings are applied by the LVM driver which modifies the default behaviour of LVM snapshot:
+The LVM driver supports creating snapshots of the LVM volumes. This requires the `dm-snapshot` kernel module to be loaded. Certain settings are applied by the LVM driver which modifies the default behaviour of LVM snapshot:
 
 - Snapshots created by LVM driver are ReadOnly by default as opposed to the ReadWrite snapshots created by default by `lvcreate` command
 - The size of snapshot will be set to the size of the origin volume


### PR DESCRIPTION
**Why is this PR required?**:
https://github.com/openebs/lvm-localpv/issues/163

**What this PR does?**:
It documents the fact the `dm-snapshot` kernel module needs to be loaded

**Does this PR require any upgrade changes?**:
no

**If the changes in this PR are manually verified, list down the scenarios covered:**:
I added a `modprobe dm-snapshot; echo dm-snapshot >> /etc/modules` to the installation script and verified this works afterwards.

**Any additional information for your reviewer?** :
To fully solve https://github.com/openebs/lvm-localpv/issues/163, there still needs to be some more graceful handling (no crazy busylooping) if the module is not present. Maybe backoff in case the invoked command doesn't succeed)

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
