### PR TITLE
docs(readme): fix versioned openebs chart URL in command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ If you want to fetch a versioned manifest, you can use the manifests for a
 specific OpenEBS release version, for example:
 
 ```
-$ kubectl apply -f https://github.com/openebs/charts/blob/gh-pages/versioned/3.0.0/lvm-operator.yaml
+$ kubectl apply -f https://raw.githubusercontent.com/openebs/charts/gh-pages/versioned/3.0.0/lvm-operator.yaml
 ```
 
 **NOTE:** For some Kubernetes distributions, the `kubelet` directory must be changed at all relevant places in the YAML powering the operator (both the `openebs-lvm-controller` and `openebs-lvm-node`).


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:

The chart URL in command is incorrect.
```bash
kubectl apply -f https://github.com/openebs/charts/blob/gh-pages/versioned/3.0.0/lvm-operator.yaml
```
should be
```bash
$ kubectl apply -f https://raw.githubusercontent.com/openebs/charts/gh-pages/versioned/3.0.0/lvm-operator.yaml
```

**What this PR does?**:

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

