### PR TITLE
feat(scheduler): adding SpaceWeighted scheduler

### DIFF
--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -1160,7 +1160,9 @@ metadata:
 value: 900000000
 globalDefault: false
 description: "This priority class should be used for the OpenEBS LVM localPV CSI driver controller deployment only."
+
 ---
+
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -34,10 +34,10 @@ const (
 	VolumeWeighted = "VolumeWeighted"
 
 	// pick the node where total provisioned volumes have occupied less capacity from the given volume group
-	// this will be the default scheduler when none provided
 	CapacityWeighted = "CapacityWeighted"
 
 	// pick the node which is less loaded space wise
+	// this will be the default scheduler when none provided
 	SpaceWeightedMap = "SpaceWeighted"
 )
 
@@ -123,6 +123,7 @@ func getSpaceWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
 		}
 		if maxFree > 0 {
 			// converting to SpaceWeighted by subtracting it with MaxInt64
+			// as the node which has max free space available is less loaded.
 			nmap[node.Name] = math.MaxInt64 - maxFree
 		}
 	}


### PR DESCRIPTION
fixes: https://github.com/openebs/lvm-localpv/issues/104

adding a new scheduler logic which selects the node
which has max free space available. This is better scheduling
algorithm than the volumeweighted and capacity weighted where we
don't check for the free space available on the node.

**Release note**
Making it a default scheduler, so, now onwards, for immediate binding case, the controller will pick the node which has largest free space available for provisioning the volumes.

Signed-off-by: Pawan <pawan@mayadata.io>
