### PR TITLE
[WIP] feat(shared-vg) : add support for create, delete, publish & unpublish of shared volumes

### DIFF
--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -36,7 +36,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: lvmvolumes.local.openebs.io
 spec:
@@ -77,14 +77,10 @@ spec:
         description: LVMVolume represents a LVM based volume
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -96,35 +92,29 @@ spec:
                 minLength: 1
                 type: string
               ownerNodeID:
-                description: OwnerNodeID is the Node ID where the volume group is
-                  present which is where the volume has been provisioned. OwnerNodeID
-                  can not be edited after the volume has been provisioned.
+                description: OwnerNodeID is the Node ID where the volume group is present which is where the volume has been provisioned. OwnerNodeID can not be edited after the volume has been provisioned.
                 minLength: 1
                 type: string
               shared:
-                description: Shared specifies whether the volume can be shared among
-                  multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
-                  will not allow the volumes to be mounted by more than one pods.
+                description: Shared specifies whether the volume can be shared among multiple pods. If it is not set to "yes", then the LVM LocalPV Driver will not allow the volumes to be mounted by more than one pods.
                 enum:
                 - "yes"
                 - "no"
                 type: string
+              sharedMode:
+                description: SharedMode specifies whether the volume can be accessed from multiple nodes which are connected to the same storage device. Currently, only "none" and "exclusive" modes are allowed.
+                type: string
               thinProvision:
-                description: ThinProvision specifies whether logical volumes can be
-                  thinly provisioned. If it is set to "yes", then the LVM LocalPV
-                  Driver will create thinProvision i.e. logical volumes that are larger
-                  than the available extents.
+                description: ThinProvision specifies whether logical volumes can be thinly provisioned. If it is set to "yes", then the LVM LocalPV Driver will create thinProvision i.e. logical volumes that are larger than the available extents.
                 enum:
                 - "yes"
                 - "no"
                 type: string
               vgPattern:
-                description: VgPattern specifies the regex to choose volume groups
-                  where volume needs to be created.
+                description: VgPattern specifies the regex to choose volume groups where volume needs to be created.
                 type: string
               volGroup:
-                description: VolGroup specifies the name of the volume group where
-                  the volume has been created.
+                description: VolGroup specifies the name of the volume group where the volume has been created.
                 type: string
             required:
             - capacity
@@ -133,27 +123,19 @@ spec:
             - volGroup
             type: object
           status:
-            description: VolStatus string that specifies the current state of the
-              volume provisioning request.
+            description: VolStatus string that specifies the current state of the volume provisioning request.
             properties:
               error:
-                description: Error denotes the error occurred during provisioning/expanding
-                  a volume. Error field should only be set when State becomes Failed.
+                description: Error denotes the error occurred during provisioning/expanding a volume. Error field should only be set when State becomes Failed.
                 properties:
                   code:
-                    description: VolumeErrorCode represents the error code to represent
-                      specific class of errors.
+                    description: VolumeErrorCode represents the error code to represent specific class of errors.
                     type: string
                   message:
                     type: string
                 type: object
               state:
-                description: State specifies the current state of the volume provisioning
-                  request. The state "Pending" means that the volume creation request
-                  has not processed yet. The state "Ready" means that the volume has
-                  been created and it is ready for the use. "Failed" means that volume
-                  provisioning has been failed and will not be retried by node agent
-                  controller.
+                description: State specifies the current state of the volume provisioning request. The state "Pending" means that the volume creation request has not processed yet. The state "Ready" means that the volume has been created and it is ready for the use. "Failed" means that volume provisioning has been failed and will not be retried by node agent controller.
                 enum:
                 - Pending
                 - Ready
@@ -189,7 +171,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: lvmsnapshots.local.openebs.io
 spec:
@@ -207,14 +189,10 @@ spec:
         description: LVMSnapshot represents an LVM Snapshot of the lvm volume
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -222,25 +200,21 @@ spec:
             description: LVMSnapshotSpec defines LVMSnapshot spec
             properties:
               ownerNodeID:
-                description: OwnerNodeID is the Node ID where the volume group is
-                  present which is where the snapshot has been provisioned. OwnerNodeID
-                  can not be edited after the snapshot has been provisioned.
+                description: OwnerNodeID is the Node ID where the volume group is present which is where the snapshot has been provisioned. OwnerNodeID can not be edited after the snapshot has been provisioned.
                 minLength: 1
                 type: string
               snapSize:
                 description: SnapSize specifies the space reserved for the snapshot
                 type: string
               volGroup:
-                description: VolGroup specifies the name of the volume group where
-                  the snapshot has been created.
+                description: VolGroup specifies the name of the volume group where the snapshot has been created.
                 type: string
             required:
             - ownerNodeID
             - volGroup
             type: object
           status:
-            description: SnapStatus string that reflects if the snapshot was created
-              successfully
+            description: SnapStatus string that reflects if the snapshot was created successfully
             properties:
               state:
                 type: string
@@ -274,7 +248,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: lvmnodes.local.openebs.io
 spec:
@@ -291,34 +265,27 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: LVMNode records information about all lvm volume groups available
-          in a node. In general, the openebs node-agent creates the LVMNode object
-          & periodically synchronizing the volume groups available in the node. LVMNode
-          has an owner reference pointing to the corresponding node object.
+        description: LVMNode records information about all lvm volume groups available in a node. In general, the openebs node-agent creates the LVMNode object & periodically synchronizing the volume groups available in the node. LVMNode has an owner reference pointing to the corresponding node object.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           volumeGroups:
             items:
-              description: VolumeGroup specifies attributes of a given vg exists on
-                node.
+              description: VolumeGroup specifies attributes of a given vg exists on node.
               properties:
                 allocationPolicy:
-                  description: 'AllocationPolicy indicates the volume group allocation
-                    policy. AllocationPolicy has the following mapping between int
-                    and string for its value: [-1: "", 0: "normal", 1: "contiguous",
-                    2: "cling", 3: "anywhere", 4: "inherited"]'
+                  description: 'AllocationPolicy indicates the volume group allocation policy. AllocationPolicy has the following mapping between int and string for its value: [-1: "", 0: "normal", 1: "contiguous", 2: "cling", 3: "anywhere", 4: "inherited"]'
                   type: integer
+                attr:
+                  description: Attributes of the lvm volume group
+                  minLength: 1
+                  type: string
                 free:
                   anyOf:
                   - type: integer
@@ -327,50 +294,42 @@ spec:
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 lvCount:
-                  description: LVCount denotes total number of logical volumes in
-                    volume group.
+                  description: LVCount denotes total number of logical volumes in volume group.
                   format: int32
                   minimum: 0
                   type: integer
                 maxLv:
-                  description: MaxLV denotes maximum number of logical volumes allowed
-                    in volume group or 0 if unlimited.
+                  description: MaxLV denotes maximum number of logical volumes allowed in volume group or 0 if unlimited.
                   format: int32
                   type: integer
                 maxPv:
-                  description: MaxPV denotes maximum number of physical volumes allowed
-                    in volume group or 0 if unlimited.
+                  description: MaxPV denotes maximum number of physical volumes allowed in volume group or 0 if unlimited.
                   format: int32
                   type: integer
                 metadataCount:
-                  description: MetadataCount denotes number of metadata areas on the
-                    volume group.
+                  description: MetadataCount denotes number of metadata areas on the volume group.
                   format: int32
                   type: integer
                 metadataFree:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: MetadataFree specifies the available metadata area
-                    space for the volume group
+                  description: MetadataFree specifies the available metadata area space for the volume group
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 metadataSize:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: MetadataSize specifies size of smallest metadata area
-                    for the volume group
+                  description: MetadataSize specifies size of smallest metadata area for the volume group
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 metadataUsedCount:
-                  description: MetadataUsedCount denotes number of used metadata areas
-                    in volume group
+                  description: MetadataUsedCount denotes number of used metadata areas in volume group
                   format: int32
                   type: integer
                 missingPvCount:
-                  description: MissingPVCount denotes number of physical volumes in
-                    volume group which are missing.
+                  description: MissingPVCount denotes number of physical volumes in volume group which are missing.
                   format: int32
                   type: integer
                 name:
@@ -378,14 +337,10 @@ spec:
                   minLength: 1
                   type: string
                 permissions:
-                  description: 'Permission indicates the volume group permission which
-                    can be writable or read-only. Permission has the following mapping
-                    between int and string for its value: [-1: "", 0: "writeable",
-                    1: "read-only"]'
+                  description: 'Permission indicates the volume group permission which can be writable or read-only. Permission has the following mapping between int and string for its value: [-1: "", 0: "writeable", 1: "read-only"]'
                   type: integer
                 pvCount:
-                  description: PVCount denotes total number of physical volumes constituting
-                    the volume group.
+                  description: PVCount denotes total number of physical volumes constituting the volume group.
                   format: int32
                   minimum: 0
                   type: integer
@@ -406,6 +361,7 @@ spec:
                   type: string
               required:
               - allocationPolicy
+              - attr
               - free
               - lvCount
               - maxLv

--- a/deploy/yamls/lvmnode-crd.yaml
+++ b/deploy/yamls/lvmnode-crd.yaml
@@ -15,7 +15,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: lvmnodes.local.openebs.io
 spec:
@@ -32,34 +32,27 @@ spec:
   - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: LVMNode records information about all lvm volume groups available
-          in a node. In general, the openebs node-agent creates the LVMNode object
-          & periodically synchronizing the volume groups available in the node. LVMNode
-          has an owner reference pointing to the corresponding node object.
+        description: LVMNode records information about all lvm volume groups available in a node. In general, the openebs node-agent creates the LVMNode object & periodically synchronizing the volume groups available in the node. LVMNode has an owner reference pointing to the corresponding node object.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           volumeGroups:
             items:
-              description: VolumeGroup specifies attributes of a given vg exists on
-                node.
+              description: VolumeGroup specifies attributes of a given vg exists on node.
               properties:
                 allocationPolicy:
-                  description: 'AllocationPolicy indicates the volume group allocation
-                    policy. AllocationPolicy has the following mapping between int
-                    and string for its value: [-1: "", 0: "normal", 1: "contiguous",
-                    2: "cling", 3: "anywhere", 4: "inherited"]'
+                  description: 'AllocationPolicy indicates the volume group allocation policy. AllocationPolicy has the following mapping between int and string for its value: [-1: "", 0: "normal", 1: "contiguous", 2: "cling", 3: "anywhere", 4: "inherited"]'
                   type: integer
+                attr:
+                  description: Attributes of the lvm volume group
+                  minLength: 1
+                  type: string
                 free:
                   anyOf:
                   - type: integer
@@ -68,50 +61,42 @@ spec:
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 lvCount:
-                  description: LVCount denotes total number of logical volumes in
-                    volume group.
+                  description: LVCount denotes total number of logical volumes in volume group.
                   format: int32
                   minimum: 0
                   type: integer
                 maxLv:
-                  description: MaxLV denotes maximum number of logical volumes allowed
-                    in volume group or 0 if unlimited.
+                  description: MaxLV denotes maximum number of logical volumes allowed in volume group or 0 if unlimited.
                   format: int32
                   type: integer
                 maxPv:
-                  description: MaxPV denotes maximum number of physical volumes allowed
-                    in volume group or 0 if unlimited.
+                  description: MaxPV denotes maximum number of physical volumes allowed in volume group or 0 if unlimited.
                   format: int32
                   type: integer
                 metadataCount:
-                  description: MetadataCount denotes number of metadata areas on the
-                    volume group.
+                  description: MetadataCount denotes number of metadata areas on the volume group.
                   format: int32
                   type: integer
                 metadataFree:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: MetadataFree specifies the available metadata area
-                    space for the volume group
+                  description: MetadataFree specifies the available metadata area space for the volume group
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 metadataSize:
                   anyOf:
                   - type: integer
                   - type: string
-                  description: MetadataSize specifies size of smallest metadata area
-                    for the volume group
+                  description: MetadataSize specifies size of smallest metadata area for the volume group
                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                   x-kubernetes-int-or-string: true
                 metadataUsedCount:
-                  description: MetadataUsedCount denotes number of used metadata areas
-                    in volume group
+                  description: MetadataUsedCount denotes number of used metadata areas in volume group
                   format: int32
                   type: integer
                 missingPvCount:
-                  description: MissingPVCount denotes number of physical volumes in
-                    volume group which are missing.
+                  description: MissingPVCount denotes number of physical volumes in volume group which are missing.
                   format: int32
                   type: integer
                 name:
@@ -119,14 +104,10 @@ spec:
                   minLength: 1
                   type: string
                 permissions:
-                  description: 'Permission indicates the volume group permission which
-                    can be writable or read-only. Permission has the following mapping
-                    between int and string for its value: [-1: "", 0: "writeable",
-                    1: "read-only"]'
+                  description: 'Permission indicates the volume group permission which can be writable or read-only. Permission has the following mapping between int and string for its value: [-1: "", 0: "writeable", 1: "read-only"]'
                   type: integer
                 pvCount:
-                  description: PVCount denotes total number of physical volumes constituting
-                    the volume group.
+                  description: PVCount denotes total number of physical volumes constituting the volume group.
                   format: int32
                   minimum: 0
                   type: integer
@@ -147,6 +128,7 @@ spec:
                   type: string
               required:
               - allocationPolicy
+              - attr
               - free
               - lvCount
               - maxLv

--- a/deploy/yamls/lvmsnapshot-crd.yaml
+++ b/deploy/yamls/lvmsnapshot-crd.yaml
@@ -15,7 +15,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: lvmsnapshots.local.openebs.io
 spec:
@@ -33,14 +33,10 @@ spec:
         description: LVMSnapshot represents an LVM Snapshot of the lvm volume
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -48,25 +44,21 @@ spec:
             description: LVMSnapshotSpec defines LVMSnapshot spec
             properties:
               ownerNodeID:
-                description: OwnerNodeID is the Node ID where the volume group is
-                  present which is where the snapshot has been provisioned. OwnerNodeID
-                  can not be edited after the snapshot has been provisioned.
+                description: OwnerNodeID is the Node ID where the volume group is present which is where the snapshot has been provisioned. OwnerNodeID can not be edited after the snapshot has been provisioned.
                 minLength: 1
                 type: string
               snapSize:
                 description: SnapSize specifies the space reserved for the snapshot
                 type: string
               volGroup:
-                description: VolGroup specifies the name of the volume group where
-                  the snapshot has been created.
+                description: VolGroup specifies the name of the volume group where the snapshot has been created.
                 type: string
             required:
             - ownerNodeID
             - volGroup
             type: object
           status:
-            description: SnapStatus string that reflects if the snapshot was created
-              successfully
+            description: SnapStatus string that reflects if the snapshot was created successfully
             properties:
               state:
                 type: string

--- a/deploy/yamls/lvmvolume-crd.yaml
+++ b/deploy/yamls/lvmvolume-crd.yaml
@@ -15,7 +15,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.5.0
   creationTimestamp: null
   name: lvmvolumes.local.openebs.io
 spec:
@@ -56,14 +56,10 @@ spec:
         description: LVMVolume represents a LVM based volume
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
@@ -75,35 +71,29 @@ spec:
                 minLength: 1
                 type: string
               ownerNodeID:
-                description: OwnerNodeID is the Node ID where the volume group is
-                  present which is where the volume has been provisioned. OwnerNodeID
-                  can not be edited after the volume has been provisioned.
+                description: OwnerNodeID is the Node ID where the volume group is present which is where the volume has been provisioned. OwnerNodeID can not be edited after the volume has been provisioned.
                 minLength: 1
                 type: string
               shared:
-                description: Shared specifies whether the volume can be shared among
-                  multiple pods. If it is not set to "yes", then the LVM LocalPV Driver
-                  will not allow the volumes to be mounted by more than one pods.
+                description: Shared specifies whether the volume can be shared among multiple pods. If it is not set to "yes", then the LVM LocalPV Driver will not allow the volumes to be mounted by more than one pods.
                 enum:
                 - "yes"
                 - "no"
                 type: string
+              sharedMode:
+                description: SharedMode specifies whether the volume can be accessed from multiple nodes which are connected to the same storage device. Currently, only "none" and "exclusive" modes are allowed.
+                type: string
               thinProvision:
-                description: ThinProvision specifies whether logical volumes can be
-                  thinly provisioned. If it is set to "yes", then the LVM LocalPV
-                  Driver will create thinProvision i.e. logical volumes that are larger
-                  than the available extents.
+                description: ThinProvision specifies whether logical volumes can be thinly provisioned. If it is set to "yes", then the LVM LocalPV Driver will create thinProvision i.e. logical volumes that are larger than the available extents.
                 enum:
                 - "yes"
                 - "no"
                 type: string
               vgPattern:
-                description: VgPattern specifies the regex to choose volume groups
-                  where volume needs to be created.
+                description: VgPattern specifies the regex to choose volume groups where volume needs to be created.
                 type: string
               volGroup:
-                description: VolGroup specifies the name of the volume group where
-                  the volume has been created.
+                description: VolGroup specifies the name of the volume group where the volume has been created.
                 type: string
             required:
             - capacity
@@ -112,27 +102,19 @@ spec:
             - volGroup
             type: object
           status:
-            description: VolStatus string that specifies the current state of the
-              volume provisioning request.
+            description: VolStatus string that specifies the current state of the volume provisioning request.
             properties:
               error:
-                description: Error denotes the error occurred during provisioning/expanding
-                  a volume. Error field should only be set when State becomes Failed.
+                description: Error denotes the error occurred during provisioning/expanding a volume. Error field should only be set when State becomes Failed.
                 properties:
                   code:
-                    description: VolumeErrorCode represents the error code to represent
-                      specific class of errors.
+                    description: VolumeErrorCode represents the error code to represent specific class of errors.
                     type: string
                   message:
                     type: string
                 type: object
               state:
-                description: State specifies the current state of the volume provisioning
-                  request. The state "Pending" means that the volume creation request
-                  has not processed yet. The state "Ready" means that the volume has
-                  been created and it is ready for the use. "Failed" means that volume
-                  provisioning has been failed and will not be retried by node agent
-                  controller.
+                description: State specifies the current state of the volume provisioning request. The state "Pending" means that the volume creation request has not processed yet. The state "Ready" means that the volume has been created and it is ready for the use. "Failed" means that volume provisioning has been failed and will not be retried by node agent controller.
                 enum:
                 - Pending
                 - Ready

--- a/go.sum
+++ b/go.sum
@@ -42,11 +42,9 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -178,7 +176,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -249,7 +246,6 @@ github.com/jpillora/go-ogle-analytics v0.0.0-20161213085824-14b04e0594ef/go.mod 
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
-github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/json-iterator/go v1.1.11 h1:uVUAXhF2To8cbw/3xN3pxj6kk7TYKs98NIrTqPlMWAQ=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -262,7 +258,6 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -335,7 +330,6 @@ github.com/prometheus/client_golang v0.9.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
-github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
@@ -348,7 +342,6 @@ github.com/prometheus/common v0.0.0-20180801064454-c7de2306084e/go.mod h1:daVV7q
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.26.0 h1:iMAkS2TDoNWnKM+Kopnx/8tnEStIfpYA0ur0xQzzhMQ=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
@@ -357,7 +350,6 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
-github.com/prometheus/procfs v0.2.0 h1:wH4vA7pcjKuZzjF7lM8awk4fnuJO6idemZXoKnULUx4=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
@@ -370,7 +362,6 @@ github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -539,7 +530,6 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201112073958-5cba982894dd h1:5CtCZbICpIOFdgO940moixOPjc0178IU44m4EjOO5IY=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40 h1:JWgyZ1qgdTaF3N3oxC+MdTV7qvEEgHo3otj+HB5CM7Q=
@@ -652,7 +642,6 @@ google.golang.org/grpc v1.34.2 h1:gpVtRHX/KWxFrkm5GsqBJ2LHSYVcjjezFU1VsRzgrRU=
 google.golang.org/grpc v1.34.2/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -675,7 +664,6 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.5/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/apis/openebs.io/lvm/v1alpha1/lvmnode.go
+++ b/pkg/apis/openebs.io/lvm/v1alpha1/lvmnode.go
@@ -50,6 +50,11 @@ type VolumeGroup struct {
 	// +kubebuilder:validation:MinLength=1
 	UUID string `json:"uuid"`
 
+	// Attributes of the lvm volume group
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
+	Attribute string `json:"attr"`
+
 	// Size specifies the total size of volume group.
 	// +kubebuilder:validation:Required
 	Size resource.Quantity `json:"size"`

--- a/pkg/apis/openebs.io/lvm/v1alpha1/lvmvolume.go
+++ b/pkg/apis/openebs.io/lvm/v1alpha1/lvmvolume.go
@@ -87,6 +87,12 @@ type VolumeInfo struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=yes;no
 	ThinProvision string `json:"thinProvision,omitempty"`
+
+	// SharedMode specifies whether the volume can be accessed from
+	// multiple nodes which are connected to the same storage device.
+	// Currently, only "none" and "exclusive" modes are allowed.
+	// +kubebuilder:validation:Required
+	SharedMode SharedModeType `json:"sharedMode,omitempty"`
 }
 
 // VolStatus string that specifies the current state of the volume provisioning request.
@@ -114,10 +120,22 @@ type VolumeError struct {
 // specific class of errors.
 type VolumeErrorCode string
 
+// SharedModeType represents the different mode of sharing
+// a LVM volume group
+type SharedModeType string
+
 const (
 	// Internal represents system internal error.
 	Internal VolumeErrorCode = "Internal"
 	// InsufficientCapacity represent lvm vg doesn't
 	// have enough capacity to fit the lv request.
 	InsufficientCapacity VolumeErrorCode = "InsufficientCapacity"
+)
+
+const (
+	// LVMExclusiveSharedMode represents that the volume is activated in exclusive
+	// mode, allowing a single host to  activate the  LV at any time
+	LVMExclusiveSharedMode SharedModeType = "exclusive"
+	// LVMNoneSharedMode represents the volumes are not to be shared among hosts
+	LVMNoneSharedMode SharedModeType = "none"
 )

--- a/pkg/builder/volbuilder/volume.go
+++ b/pkg/builder/volbuilder/volume.go
@@ -133,6 +133,22 @@ func (b *Builder) WithShared(shared string) *Builder {
 	return b
 }
 
+// WithSharedMode sets in which mode volumes are accessible.
+// There can be 3 different modes:
+// 	1. none(default mode) - the LVs can only be accessed locally
+// 	2. exclusive - the LVs can be accessed from multiple nodes but in an exclusive manner(active on one node at a time)
+// 	3. shared - the LVs can be accessed from multiple nodes(can be active on multiple nodes at a node)
+// NOTE: shared mode is currently not supported
+func (b *Builder) WithSharedMode(mode string) *Builder {
+	// Update the ShredMode only when the permitted values are used.
+	if mode == string(apis.LVMExclusiveSharedMode) || mode == string(apis.LVMNoneSharedMode) {
+		b.volume.Object.Spec.SharedMode = apis.SharedModeType(mode)
+	} else {
+		b.volume.Object.Spec.SharedMode = apis.LVMNoneSharedMode
+	}
+	return b
+}
+
 // WithThinProvision sets where thinProvision is enable or not
 func (b *Builder) WithThinProvision(thinProvision string) *Builder {
 	b.volume.Object.Spec.ThinProvision = thinProvision

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -246,6 +246,12 @@ func CreateLVMVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 	capacity := strconv.FormatInt(getRoundedCapacity(
 		req.GetCapacityRange().RequiredBytes), 10)
 
+	// Thin provisioning is not allowed for shared volumes currently
+	// TODO add support for thin provisioning for shared volumes
+	if lvmapi.SharedModeType(params.SharedMode) == lvmapi.LVMExclusiveSharedMode && params.ThinProvision == lvm.YES {
+		return nil, status.Errorf(codes.Internal, "Thin provisioning not allowed for shared volumes")
+	}
+
 	vol, err := lvm.GetLVMVolume(volName)
 	if err != nil {
 		if !k8serror.IsNotFound(err) {

--- a/pkg/driver/params.go
+++ b/pkg/driver/params.go
@@ -35,6 +35,7 @@ type VolumeParams struct {
 
 	Scheduler     string
 	Shared        string
+	SharedMode    string
 	ThinProvision string
 	// extra optional metadata passed by external provisioner
 	// if enabled. See --extra-create-metadata flag for more details.
@@ -56,6 +57,7 @@ func NewVolumeParams(m map[string]string) (*VolumeParams, error) {
 	params := &VolumeParams{ // set up defaults, if any.
 		Scheduler:     CapacityWeighted,
 		Shared:        "no",
+		SharedMode:    "none",
 		ThinProvision: "no",
 	}
 	// parameter keys may be mistyped from the CRD specification when declaring
@@ -82,6 +84,7 @@ func NewVolumeParams(m map[string]string) (*VolumeParams, error) {
 	stringParams := map[string]*string{
 		"scheduler":     &params.Scheduler,
 		"shared":        &params.Shared,
+		"sharedmode":    &params.SharedMode,
 		"thinprovision": &params.ThinProvision,
 	}
 	for key, param := range stringParams {

--- a/pkg/lvm/constants.go
+++ b/pkg/lvm/constants.go
@@ -20,6 +20,7 @@ package lvm
 const (
 	VGName              = "vg_name"
 	VGUUID              = "vg_uuid"
+	VGAttr              = "vg_attr"
 	VGPVvount           = "pv_count"
 	VGLvCount           = "lv_count"
 	VGMaxLv             = "max_lv"

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -350,24 +350,13 @@ func ActivateLVMLogicalVolume(vol *apis.LVMVolume, activate bool) error {
 		lvStateArg = "-an"
 	}
 
-	// change the state of thin pool first if thin volumes are provisioned
-	if vol.Spec.ThinProvision == YES {
-		// check buildLVMCreateArgs() in the current file to see how thin pool name is formed
-		pool := vol.Spec.VolGroup + "_thinpool"
-		cmd := exec.Command(LVChange, lvStateArg, vol.Spec.VolGroup+"/"+pool)
-		_, err := cmd.CombinedOutput()
-		if err != nil {
-			klog.Errorf("failed to change thin pool {%s}'s state: %v", pool, err)
-			return err
-		}
-	}
-
 	// change the state of the volume
 	volume := vol.Spec.VolGroup + "/" + vol.Name
 	cmd := exec.Command(LVChange, lvStateArg, volume)
-	_, err := cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
 	if err != nil {
 		klog.Errorf("failed to change the volume {%s}'s state: %v", volume, err)
+		err = newExecError(out, err)
 		return err
 	}
 

--- a/pkg/mgmt/volume/volume.go
+++ b/pkg/mgmt/volume/volume.go
@@ -168,6 +168,12 @@ func (c *VolController) getVgPriorityList(vol *apis.LVMVolume) ([]apis.VolumeGro
 				continue
 			}
 		}
+		// skip th vg if the volume is to be created in exclusive shared mode but the underlying
+		// vg is not shared. Shared  VGs  are indicated by "s" (for shared) in the sixth attr
+		// field
+		if vol.Spec.SharedMode == apis.LVMExclusiveSharedMode && vg.Attribute[5] != 's' {
+			continue
+		}
 		filteredVgs = append(filteredVgs, vg)
 	}
 


### PR DESCRIPTION
Signed-off-by: Abhishek Agarwal <abhishek.agarwal@mayadata.io>

**Why is this PR required? What issue does it fix?**:
This PR addresses the issue of adding support for creating volumes LVM2 shared volume groups.

**What this PR does?**:
Add new features for volumes on top of shared volume groups. This PR adds support for the following workflows:
1. Creating an exclusively shared volume on shared volume group.
2. Deleting an exclusively shared volume on shared volume group.
3. Publishing(mounting) an exclusively shared LVM volume onto a pod.
4. Unpublishing(unmounting) an exclusively shared LVM volume.

NOTE: 
1. This PR only adds support for **exclusively** shared LVM volume.
2. Features such as volume expanding and volume snapshots are not supported for exclusively shared LVM volumes.

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Testing is yet to be done

**Any additional information for your reviewer?** :
Design doc for this PR: https://docs.google.com/document/d/1QJUPW3C8DSSwRkCjgh_O472KfZcgTnU9/edit?usp=sharing&ouid=106351714067742402436&rtpof=true&sd=true 


**Checklist:**
- [x] Fixes #134 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
