### PR TITLE
refact(e2e): skip ssl certificate check in ansible module for lvm-operator file download

### DIFF
--- a/e2e-tests/experiments/lvm-localpv-provisioner/test.yml
+++ b/e2e-tests/experiments/lvm-localpv-provisioner/test.yml
@@ -25,6 +25,7 @@
          get_url:
            url: https://raw.githubusercontent.com/openebs/lvm-localpv/{{ lvm_branch }}/deploy/lvm-operator.yaml
            dest: ./lvm_operator.yml
+           validate_certs: false
            force: yes
          register: status
          until: "'OK' in status.msg"

--- a/e2e-tests/experiments/upgrade-lvm-localpv/test.yml
+++ b/e2e-tests/experiments/upgrade-lvm-localpv/test.yml
@@ -65,6 +65,7 @@
           get_url:
             url: https://raw.githubusercontent.com/openebs/lvm-localpv/{{ to_version_lvm_branch }}/deploy/lvm-operator.yaml
             dest: ./new_lvm_operator.yml
+            validate_certs: false
             force: yes
           register: result
           until: "'OK' in result.msg"


### PR DESCRIPTION

Signed-off-by: Aman Gupta <aman@aman-mbp1.local>

- Skipping the ssl certificate validation in ansible module to download lvm-operator files.