### PR TITLE
feat(lvm-localpv): make the installation of snapshot.storage.k8s.io CRDs optional

### DIFF
--- a/deploy/helm/charts/templates/volumesnapshotclasses-crd.yaml
+++ b/deploy/helm/charts/templates/volumesnapshotclasses-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd.volumeSnapshot }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -108,5 +109,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-
-
+{{- end }}

--- a/deploy/helm/charts/templates/volumesnapshotcontents-crd.yaml
+++ b/deploy/helm/charts/templates/volumesnapshotcontents-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd.volumeSnapshot }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -289,3 +290,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/deploy/helm/charts/templates/volumesnapshots-crd.yaml
+++ b/deploy/helm/charts/templates/volumesnapshots-crd.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.crd.volumeSnapshot }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -223,3 +224,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
+{{- end }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -151,6 +151,8 @@ role: openebs-lvm
 
 crd:
   enableInstall: true
+  # Disable the installation of the volume snapshot CRDs if your Kubernetes distribution or another storage operator already manages them.
+  volumeSnapshot: true
 
 serviceAccount:
   lvmController:


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
change for #203 

**What this PR does?**:
This PR will enable the possibility to disable the installation of the volumesnapshot CRDs.
To prevent any regressions, the default has been set to true.
These resources are usually maintained and managed by the underlying kubernetes distribution. In case of OpenShift, it will automatically revert back the modifications made by this helmchart. This could be problematic if you use ArgoCD and have it on autosync.

**Checklist:**
- [x] Fixes #203 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
