### PR TITLE
fix(exporter): ignore duplicate LVs when collecting metrics

### DIFF
--- a/changelogs/unreleased/212-patrickjahns
+++ b/changelogs/unreleased/212-patrickjahns
@@ -1,0 +1,1 @@
+fixed metrics collection when LVs have several segments

--- a/pkg/collector/collector_util.go
+++ b/pkg/collector/collector_util.go
@@ -1,0 +1,26 @@
+/*
+Copyright 2021 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+func contains(list []string, item string) bool {
+	for _, e := range list {
+		if e == item {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/collector/lv_collector.go
+++ b/pkg/collector/lv_collector.go
@@ -103,7 +103,13 @@ func (c *lvCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		klog.Errorf("error in getting the list of lvm logical volumes: %v", err)
 	} else {
+		var lvIDS []string
 		for _, lv := range lvList {
+			if contains(lvIDS, lv.UUID) {
+				klog.V(2).Infof("duplicate entry for LV: %s", lv.UUID)
+				continue
+			}
+			lvIDS = append(lvIDS, lv.UUID)
 			ch <- prometheus.MustNewConstMetric(c.lvSizeMetric, prometheus.GaugeValue, float64(lv.Size), lv.Name, lv.Device)
 			ch <- prometheus.MustNewConstMetric(c.lvTotalSizeMetric, prometheus.GaugeValue, float64(lv.Size), lv.Name, lv.Path, lv.DMPath, lv.VGName, lv.Device, lv.Host, lv.SegType, lv.PoolName, lv.ActiveStatus)
 			ch <- prometheus.MustNewConstMetric(c.lvUsedSizePercentMetric, prometheus.GaugeValue, lv.UsedSizePercent, lv.Name, lv.Path, lv.DMPath, lv.VGName, lv.Device, lv.Host, lv.SegType, lv.PoolName, lv.ActiveStatus)


### PR DESCRIPTION
## Pull Request template

**Why is this PR required? What issue does it fix?**:

When LVs have more than a single segment(i.e. spread over several), collecting the metrics does no longer work, as `lvs` returns several entries for the same LV

**What this PR does?**:

As I did not want to change the behaviour of `ListLVMLogicalVolume` (even though its currently only used in metrics collection. I opted for skipping any further occurrences of the LV (per UUID) during metric collection. 


**Does this PR require any upgrade changes?**: NO

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Assuming a VG with 100GB
- Create 2 PVCs with 10GB size
- Delete the PVC that sits before the second 10GB on the VG
- Create a PVC with 85GB in size, so the LV will end up having two segments
- Collect metrics and see no scrape errors


**Checklist:**
- [x] Fixes #211
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
