### PR TITLE
Update correct volume group name in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Create the Volume group on all the nodes, which will be used by the LVM Driver f
 
 ```
 sudo pvcreate /dev/loop0
-sudo vgcreate lvmvg /dev/loop0       ## here lvmvg is the volume group name to be created
+sudo vgcreate lvmpv-vg /dev/loop0       ## here lvmvg is the volume group name to be created
 ```
 
 ### Installation


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
**Fix this error while create PVC in K8s:** 

`Warning  ProvisioningFailed    64s (x8 over 3m13s)   local.csi.openebs.io_openebs-lvm-controller-0_c6baa0a4-8d08-43d5-8521-8fb877620fd9  failed to provision volume with StorageClass "openebs-lvmpv": rpc error: code = ResourceExhausted desc = no vg available to serve volume request having regex="^lvmpv-vg$" & capacity="4294967296"`

**What this PR does?**:
**Correct document text**

**Does this PR require any upgrade changes?**:
**No**

**If the changes in this PR are manually verified, list down the scenarios covered:**:
**Correct group name when setup volume group in node**

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


