### PR TITLE
fix(localpv): expose Kubernetes client QPS and Burst as flags

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -97,6 +97,14 @@ func main() {
 		&config.DisableExporterMetrics, "disable-exporter-metrics", true, "Exclude metrics about the exporter itself (process_*, go_*).",
 	)
 
+	cmd.PersistentFlags().IntVar(
+		&config.KubeAPIQPS, "kube-api-qps", 0, "QPS to use while talking with Kubernetes API server.",
+	)
+
+	cmd.PersistentFlags().IntVar(
+		&config.KubeAPIBurst, "kube-api-burst", 0, "Burst to allow while talking with Kubernetes API server.",
+	)
+
 	config.RIopsLimitPerGB = cmd.PersistentFlags().StringSlice(
 		"riops-per-gb", []string{},
 		"Read IOPS per GB limit to use for each volume group prefix, "+

--- a/pkg/driver/config/config.go
+++ b/pkg/driver/config/config.go
@@ -79,6 +79,12 @@ type Config struct {
 
 	// Exclude metrics about the exporter itself (process_*, go_*).
 	DisableExporterMetrics bool
+
+	// KubeAPIQPS is the QPS to use while talking with Kubernetes API server.
+	KubeAPIQPS int
+
+	// KubeAPIBurst is the burst to allow while talking with Kubernetes API server.
+	KubeAPIBurst int
 }
 
 // Default returns a new instance of config

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -179,6 +179,16 @@ func (cs *controller) init() error {
 		return errors.Wrapf(err, "failed to build kubeconfig")
 	}
 
+	if cs.driver.config.KubeAPIQPS > 0 {
+		klog.Infof("setting k8s client qps to %d", cs.driver.config.KubeAPIQPS)
+		cfg.QPS = float32(cs.driver.config.KubeAPIQPS)
+	}
+
+	if cs.driver.config.KubeAPIBurst > 0 {
+		cfg.Burst = cs.driver.config.KubeAPIBurst
+		klog.Infof("setting k8s client burst to %d", cs.driver.config.KubeAPIBurst)
+	}
+
 	kubeClient, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
 		return errors.Wrap(err, "failed to build k8s clientset")


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

While running some performance tests, I noticed that there seems to be a bottleneck that is significantly delaying volumes creation. Here are the results when trying to create 5 volumes per second (see the test scenario at the end of this comment):

<img width="1903" alt="image" src="https://github.com/openebs/lvm-localpv/assets/976373/e4f8ba96-9b47-43b6-bd5b-11d6aabd38e2">

After some investigation, I noticed that the bottleneck was the Kubernetes client throttling requests.

**What this PR does?**:

This PR allows the user to set the QPS and Burst value for the K8S client. Running the same performance test as above with a `qps` of `50` and a `burst` of `100` leads to the following result:

<img width="1919" alt="image" src="https://github.com/openebs/lvm-localpv/assets/976373/12d8882d-8e32-447a-bb52-2d1296038e74">


**Does this PR require any upgrade changes?**:

No, if no `--kube-api-qps` or `--kube-api-burst` are provided, then the behavior is exactly the same as today.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Here is [ClusterLoader2](https://github.com/kubernetes/perf-tests/tree/master/clusterloader2#clusterloader) scenario used for the performance test presented above:

```yaml
## Default expected number of PVC is 300
{{$PVCS := DefaultParam .PVCS 300}}

## Set a default timeout of 30 minutes
{{$TIMEOUT := DefaultParam .TIMEOUT "1800s"}}

name: openebs-stress

namespace:
  number: 1

tuningSets:
  - name: UniformQPS
    qpsLoad:
      qps: 5

steps:
  - name: Create PVCs
    phases:
      - namespaceRange:
          min: 1
          max: 1
        replicasPerNamespace: {{$PVCS}}
        tuningSet: UniformQPS
        objectBundle:
          - basename: volume-test
            objectTemplatePath: "pvc.yaml"
  - name: Waiting for PVs to be bound
    measurements:
      - Identifier: WaitForPVCsToBeBound
        Method: WaitForBoundPVCs
        Params:
          desiredPVCCount: {{$PVCS}}
          apiVersion: v1
          labelSelector: group = volume-test
          timeout: {{$TIMEOUT}}
```

With `pvc.yaml`:

```yaml
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: {{.Name}}
  labels:
    group: volume-test
spec:
  storageClassName: "openebs-immediate" ## Update to reflect you cs
  accessModes:
    - ReadWriteOnce
  resources:
    requests:
      storage: 1Gi
```


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

