### PR TITLE
fix(lvm): change calling operation to avoid garbage in json object

### DIFF
--- a/changelogs/unreleased/250-kro-cat
+++ b/changelogs/unreleased/250-kro-cat
@@ -1,0 +1,8 @@
+Drop the STDERR stream contents from output to avoid JSON mangling.
+
+The vgs command may print non-critical warnings to STDERR. Warnings may not
+necessarily result in a failure return code, which allows the program to
+continue with marshalling the JSON-formatted output. Combining this stream with
+STDIN will cause the next step at decodeVgsJSON() to fail due to garbage mixed
+in the JSON.
+

--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -43,12 +43,20 @@ cleanup_loopdev() {
 }
 
 cleanup_lvmvg() {
-  [ -f /tmp/openebs_ci_disk.img ] && rm /tmp/openebs_ci_disk.img
+  if [ -f /tmp/openebs_ci_disk.img ]
+  then
+    sudo vgremove lvmvg -y || true
+    rm /tmp/openebs_ci_disk.img
+  fi
   cleanup_loopdev
 }
 
 cleanup_foreign_lvmvg() {
-  [ -f /tmp/openebs_ci_foreign_disk.img ] && rm /tmp/openebs_ci_foreign_disk.img
+  if [ -f /tmp/openebs_ci_foreign_disk.img ]
+  then
+    sudo vgremove foreign_lvmvg --config="${LVM_CONFIG}" -y || true
+    rm /tmp/openebs_ci_foreign_disk.img
+  fi
   cleanup_loopdev
 }
 

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -663,7 +663,7 @@ func ListLVMVolumeGroup(reloadCache bool) ([]apis.VolumeGroup, error) {
 		"--units", "b",
 	}
 	cmd := exec.Command(VGList, args...)
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
 		klog.Errorf("lvm: list volume group cmd %v: %v", args, err)
 		return nil, err


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
The `vgs` command may print non-critical warnings to STDERR. Warnings may not necessarily result in a failure return code, which allows the program to continue with marshalling the JSON-formatted output. Combining this stream with STDIN will cause the next step at `decodeVgsJSON()` to fail due to garbage mixed in the JSON.

**What this PR does?**:
Drop the STDERR stream contents from `output` to avoid JSON mangling.

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
Volume groups created on the host may not necessarily be compatible with the lvm-driver container. This PR simply introduces a fix to isolate any warnings generated by `vgs`, but this won't fix any issues with incompatible volume groups: there may be additional steps required of the system's administrator in order to ensure his or her configuration will work with lvm-localpv. Printing `vgs`'s STDERR to the log should provide enough diagnostic information for the administrator to perform any additional steps, if needed.


**Checklist:**
- [x] Fixes #247, #249
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: