### PR TITLE
feat(lvm-driver): enable RAID support

### DIFF
--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -96,12 +96,13 @@ output_name="bin/${PNAME}/"$GOOS"_"$GOARCH"/"$CTLNAME
 if [ $GOOS = "windows" ]; then
     output_name+='.exe'
 fi
-env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags \
+env GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=0 go build -ldflags \
     "-X github.com/openebs/lvm-localpv/pkg/version.GitCommit=${GIT_COMMIT} \
     -X main.CtlName='${CTLNAME}' \
     -X github.com/openebs/lvm-localpv/pkg/version.Version=${VERSION} \
     -X github.com/openebs/lvm-localpv/pkg/version.VersionMeta=${VERSION_META}"\
     -o $output_name\
+    -installsuffix cgo \
     ./cmd
 
 echo ""

--- a/changelogs/unreleased/164-nicholascioli
+++ b/changelogs/unreleased/164-nicholascioli
@@ -1,0 +1,1 @@
+add support for LVM raid options

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -95,11 +95,46 @@ spec:
                 description: Capacity of the volume
                 minLength: 1
                 type: string
+              integrity:
+                description: Integrity specifies whether logical volumes should be
+                  checked for integrity. If it is set to "yes", then the LVM LocalPV
+                  Driver will enable DM integrity for the logical volume
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              lvcreateoptions:
+                description: LvCreateOptions are extra options for creating a volume.
+                  Options should be separated by ; e.g. "--vdo;--readahead;auto"
+                type: string
+              mirrors:
+                description: Mirrors specifies the mirror count for a RAID configuration.
+                minimum: 0
+                type: integer
+              nosync:
+                description: NoSync enables the `--nosync` option of a RAID volume.
+                  If it is set to "yes", then LVM will skip drive sync when creating
+                  the mirrors. Defaults to "no"
+                enum:
+                - "yes"
+                - "no"
+                type: string
               ownerNodeID:
                 description: OwnerNodeID is the Node ID where the volume group is
                   present which is where the volume has been provisioned. OwnerNodeID
                   can not be edited after the volume has been provisioned.
                 minLength: 1
+                type: string
+              raidtype:
+                description: RaidType specifies the type of RAID for the logical volume.
+                  Defaults to linear, if unspecified.
+                enum:
+                - linear
+                - raid0
+                - raid1
+                - raid5
+                - raid6
+                - raid10
                 type: string
               shared:
                 description: Shared specifies whether the volume can be shared among
@@ -109,6 +144,18 @@ spec:
                 - "yes"
                 - "no"
                 type: string
+              stripecount:
+                description: StripeCount specifies the stripe count for a RAID configuration.
+                  This is equal to the number of physical volumes to scatter the logical
+                  volume
+                minimum: 0
+                type: integer
+              stripesize:
+                description: StripeSize specifies the size of a stripe for a RAID
+                  configuration. Must be a power of 2 but must not exceed the physical
+                  extent size
+                minimum: 0
+                type: integer
               thinProvision:
                 description: ThinProvision specifies whether logical volumes can be
                   thinly provisioned. If it is set to "yes", then the LVM LocalPV
@@ -129,6 +176,7 @@ spec:
             required:
             - capacity
             - ownerNodeID
+            - raidtype
             - vgPattern
             - volGroup
             type: object

--- a/deploy/yamls/lvmvolume-crd.yaml
+++ b/deploy/yamls/lvmvolume-crd.yaml
@@ -74,11 +74,46 @@ spec:
                 description: Capacity of the volume
                 minLength: 1
                 type: string
+              integrity:
+                description: Integrity specifies whether logical volumes should be
+                  checked for integrity. If it is set to "yes", then the LVM LocalPV
+                  Driver will enable DM integrity for the logical volume
+                enum:
+                - "yes"
+                - "no"
+                type: string
+              lvcreateoptions:
+                description: LvCreateOptions are extra options for creating a volume.
+                  Options should be separated by ; e.g. "--vdo;--readahead;auto"
+                type: string
+              mirrors:
+                description: Mirrors specifies the mirror count for a RAID configuration.
+                minimum: 0
+                type: integer
+              nosync:
+                description: NoSync enables the `--nosync` option of a RAID volume.
+                  If it is set to "yes", then LVM will skip drive sync when creating
+                  the mirrors. Defaults to "no"
+                enum:
+                - "yes"
+                - "no"
+                type: string
               ownerNodeID:
                 description: OwnerNodeID is the Node ID where the volume group is
                   present which is where the volume has been provisioned. OwnerNodeID
                   can not be edited after the volume has been provisioned.
                 minLength: 1
+                type: string
+              raidtype:
+                description: RaidType specifies the type of RAID for the logical volume.
+                  Defaults to linear, if unspecified.
+                enum:
+                - linear
+                - raid0
+                - raid1
+                - raid5
+                - raid6
+                - raid10
                 type: string
               shared:
                 description: Shared specifies whether the volume can be shared among
@@ -88,6 +123,18 @@ spec:
                 - "yes"
                 - "no"
                 type: string
+              stripecount:
+                description: StripeCount specifies the stripe count for a RAID configuration.
+                  This is equal to the number of physical volumes to scatter the logical
+                  volume
+                minimum: 0
+                type: integer
+              stripesize:
+                description: StripeSize specifies the size of a stripe for a RAID
+                  configuration. Must be a power of 2 but must not exceed the physical
+                  extent size
+                minimum: 0
+                type: integer
               thinProvision:
                 description: ThinProvision specifies whether logical volumes can be
                   thinly provisioned. If it is set to "yes", then the LVM LocalPV
@@ -108,6 +155,7 @@ spec:
             required:
             - capacity
             - ownerNodeID
+            - raidtype
             - vgPattern
             - volGroup
             type: object

--- a/design/lvm/storageclass-parameters/raid.md
+++ b/design/lvm/storageclass-parameters/raid.md
@@ -1,0 +1,129 @@
+---
+title: LVM-LocalPV RAID
+authors:
+  - "@nicholascioli"
+owners: []
+creation-date: 2023-11-04
+last-updated: 2023-11-04
+status: Implemented
+---
+
+# LVM-LocalPV RAID
+
+## Table of Contents
+- [LVM-LocalPV RAID](#lvm-localpv-raid)
+  - [Table of Contents](#table-of-contents)
+  - [Summary](#summary)
+  - [Motivation](#motivation)
+    - [Goals](#goals)
+    - [Non Goals](#non-goals)
+  - [Proposal](#proposal)
+    - [User Stories](#user-stories)
+    - [Implementation Details](#implementation-details)
+    - [Usage details](#usage-details)
+    - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+  - [Drawbacks](#drawbacks)
+  - [Alternatives](#alternatives)
+
+
+## Summary
+
+This proposal charts out the workflow details to support creation of RAID volumes.
+
+## Motivation
+
+### Goals
+
+- Able to provision RAID volumes in a VolumeGroup.
+- Able to specify VolumeGroup-specific RAID options for all sub volumes.
+- Able to specify extra options for all volumes in a VolumeGroup.
+
+### Non Goals
+
+- Validating combinations of RAID types / options.
+
+## Proposal
+
+### User Stories
+
+- RAIDed volumes provide data redundancy and can mitigate data loss due to individual drive failures.
+- Ability to specify extra arguments for VolumeGroups allow for user customizations without needing
+  to rework k8s schemas.
+
+### Implementation Details
+
+- User/Admin has to set RAID-sepcific options under storageclass parameters which
+  are used when creating volumes in the VolumeGroup.
+- During volume provisioning time external-provisioner will read all key-value pairs
+  that are specified under referenced storageclass and pass information to CSI
+  driver as payload for `CreateVolume` gRPC request.
+- After receiving the `CreateVolume` request CSI driver will pick appropriate node based
+  on scheduling attributes(like topology information, matching VG name and available capacity)
+  and creates LVM volume resource by setting `Spec.RaidType` to a valid type along with other properties.
+- Once the LVMVolume resource is created corresponding node LVM volume controller reconcile
+  LVM volume resource in the following way:
+  - LVM controller will check `Spec.RaidType` field, if the field is set to anything other
+    than `linear`, then the controller will perform following operations:
+    - Fetch information about existence of matching VolumeGroup.
+      - If there is a VolumeGroup with <vg_name> name then controller will create a volume.
+        Command used to create thin volume: `lvcreate --type <RAID_TYPE> --raidintegrity <INTEGRITY> --nosync ... <LVCREATEOPTIONS> -y`
+    - If volume creation is successfull then controller will LVM volume resource as `Ready`.
+- After watching `Ready` status CSI driver will return success response to `CreateVolume` gRPC
+  request.
+
+### Usage details
+
+1. User/Admin can configure the following options under the storageclass parameters.
+
+Option | Required | Valid Values | Description
+-------|----------|--------------|-------------------
+`type` | `true` | `raid0` / `stripe`, `raid` / `raid1` / `mirror`, `raid5`, `raid6`, `raid10` | The RAID type of the volume.
+`integrity` | `false` | `true`, `false` | Whether or not to enable DM integrity for the volume. Defaults to `false`.
+`mirrors` | depends | [0, ∞) | Mirror count. Certain RAID configurations require this to be set.
+`nosync` | `false` | `true`, `false` | Whether or not to disable the initial sync. Defaults to false.
+`stripecount` | depends | [0, ∞) | Stripe count. Certain RAID configurations require this to be set.
+`stripesize` | `false` | [0, ∞) (but must be a power of 2) | The size of each stripe. If not specified, LVM will choose a sane default.
+`lvcreateoptions` | `false` | String, delimited by `;` | Extra options to be passed to LVM when creating volumes.
+
+An example is shown below
+```yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: openebs-lvm
+provisioner: local.csi.openebs.io
+parameters:
+  storage: "lvm"
+  volgroup: "lvmvg"
+  raidType: "raid1"
+  lvcreateoptions: "--vdo;--readahead auto"
+```
+
+### Test Plan
+- Provision an application on various RAID configurations, verify volume accessibility from application,
+  and verify that `lvs` reports correct RAID information.
+
+## Graduation Criteria
+
+All testcases mentioned in [Test Plan](#test-plan) section need to be automated
+
+## Drawbacks
+
+- Since the RAID options exist at the storageclass level, changes to the storage
+  class RAID options is not possible without custom logic per RAID type or manual
+  operator interactions.
+- Validation of the RAID options depend on the version of LVM2 installed as well as
+  the type of RAID used and its options. This is outside of the scope of these changes
+  and will cause users to have to debug issues with a finer comb to see why certain
+  options do not work together or on their specific machine.
+
+## Alternatives
+
+RAID can be done in either software or hardware, with many off-the-shelf products
+including built-in hardware solutions. There are also other software RAID alternatives
+that can be used below LVM, such as mdadm.
+
+This unfortunately requires operators to decouple
+the SotrageClass from the RAID configuration, but does simplify the amount of code maintained by
+this project.

--- a/pkg/apis/openebs.io/lvm/v1alpha1/lvmvolume.go
+++ b/pkg/apis/openebs.io/lvm/v1alpha1/lvmvolume.go
@@ -87,6 +87,55 @@ type VolumeInfo struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:Enum=yes;no
 	ThinProvision string `json:"thinProvision,omitempty"`
+
+	// RaidType specifies the type of RAID for the logical volume.
+	// Defaults to linear, if unspecified.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:default=linear
+	// +kubebuilder:validation:Enum=linear;raid0;raid1;raid5;raid6;raid10
+	RaidType string `json:"raidtype"`
+
+	// Integrity specifies whether logical volumes should be checked for integrity.
+	// If it is set to "yes", then the LVM LocalPV Driver will enable DM integrity
+	// for the logical volume
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=yes;no
+	Integrity string `json:"integrity,omitempty"`
+
+	// Mirrors specifies the mirror count for a RAID configuration.
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:default=0
+	// +kubebuilder:validation:Minimum=0
+	Mirrors uint `json:"mirrors,omitempty"`
+
+	// NoSync enables the `--nosync` option of a RAID volume.
+	// If it is set to "yes", then LVM will skip drive sync when creating
+	// the mirrors. Defaults to "no"
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:default=no
+	// +kubebuilder:validation:Enum=yes;no
+	NoSync string `json:"nosync,omitempty"`
+
+	// StripeCount specifies the stripe count for a RAID configuration.
+	// This is equal to the number of physical volumes to scatter the
+	// logical volume
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:default=0
+	// +kubebuilder:validation:Minimum=0
+	StripeCount uint `json:"stripecount,omitempty"`
+
+	// StripeSize specifies the size of a stripe for a RAID configuration.
+	// Must be a power of 2 but must not exceed the physical extent size
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:default=0
+	// +kubebuilder:validation:Minimum=0
+	StripeSize uint `json:"stripesize,omitempty"`
+
+	// LvCreateOptions are extra options for creating a volume.
+	// Options should be separated by ;
+	// e.g. "--vdo;--readahead;auto"
+	// +kubebuilder:validation:Required
+	LvCreateOptions string `json:"lvcreateoptions,omitempty"`
 }
 
 // VolStatus string that specifies the current state of the volume provisioning request.

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -310,7 +310,15 @@ func CreateLVMVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 		WithOwnerNode(owner).
 		WithVolumeStatus(lvm.LVMStatusPending).
 		WithShared(params.Shared).
-		WithThinProvision(params.ThinProvision).Build()
+		WithThinProvision(params.ThinProvision).
+		WithRaidType(params.RaidType).
+		WithIntegrity(params.Integrity).
+		WithMirrors(params.Mirrors).
+		WithNoSync(params.NoSync).
+		WithStripeCount(params.StripeCount).
+		WithStripeSize(params.StripeSize).
+		WithLvCreateOptions(params.LvCreateOptions).
+		Build()
 
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())

--- a/pkg/driver/params.go
+++ b/pkg/driver/params.go
@@ -42,6 +42,15 @@ type VolumeParams struct {
 	PVCName      string
 	PVCNamespace string
 	PVName       string
+
+	// Raid specific options
+	RaidType        string
+	Integrity       string
+	Mirrors         string
+	NoSync          string
+	StripeCount     string
+	StripeSize      string
+	LvCreateOptions string
 }
 
 // SnapshotParams holds collection of supported settings that can
@@ -57,6 +66,12 @@ func NewVolumeParams(m map[string]string) (*VolumeParams, error) {
 		Scheduler:     SpaceWeighted,
 		Shared:        "no",
 		ThinProvision: "no",
+		RaidType:      "linear",
+		Integrity:     "no",
+		Mirrors:       "0",
+		NoSync:        "no",
+		StripeCount:   "0",
+		StripeSize:    "0",
 	}
 	// parameter keys may be mistyped from the CRD specification when declaring
 	// the storageclass, which kubectl validation will not catch. Because
@@ -83,6 +98,15 @@ func NewVolumeParams(m map[string]string) (*VolumeParams, error) {
 		"scheduler":     &params.Scheduler,
 		"shared":        &params.Shared,
 		"thinprovision": &params.ThinProvision,
+
+		// Raid options
+		"raidtype":        &params.RaidType,
+		"integrity":       &params.Integrity,
+		"mirrors":         &params.Mirrors,
+		"nosync":          &params.NoSync,
+		"stripecount":     &params.StripeCount,
+		"stripesize":      &params.StripeSize,
+		"lvcreateoptions": &params.LvCreateOptions,
 	}
 	for key, param := range stringParams {
 		value, ok := m[key]

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -43,6 +43,9 @@ import (
 const (
 	// volume group name where volume provisioning will happen
 	VOLGROUP = "lvmvg"
+
+	// volume group name where RAID volume provisioning will happen
+	RAIDGROUP = "raidvg"
 )
 
 var (

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -166,6 +166,26 @@ func createThinStorageClass() {
 	gomega.Expect(err).To(gomega.BeNil(), "while creating a thinProvision storageclass {%s}", scName)
 }
 
+func createRaidStorageClass(raidArgs map[string]string) {
+	var (
+		err error
+	)
+
+	// Add in the volume group to the args
+	raidArgs["volgroup"] = RAIDGROUP
+
+	ginkgo.By("building a RAID storage class")
+	scObj, err = sc.NewBuilder().
+		WithGenerateName(scName).
+		WithParametersNew(raidArgs).
+		WithProvisioner(LocalProvisioner).Build()
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(),
+		"while building RAID storageclass obj with prefix {%s}", scName)
+
+	scObj, err = SCClient.Create(scObj)
+	gomega.Expect(err).To(gomega.BeNil(), "while creating a RAID storageclass {%s}", scName)
+}
+
 // VerifyLVMVolume verify the properties of a lvm-volume
 func VerifyLVMVolume() {
 	ginkgo.By("fetching lvm volume")


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:

This PR adds support for RAID options when creating `StorageClass`es that translate to built-in LVM2 RAID types and options. This change also opens the door to allowing more niche LVM arguments through the new `lvcreateoptions` parameter.

**What this PR does?**:

Add support for LVM2 RAID types and parameters, with sane defaults for backwards compatibility. lvm-driver now assumes that a non-specified RAID type corresponds to the previous default of linear RAID, where data is packed onto disk until it runs out of space, continuing to the next as necessary.

**Does this PR require any upgrade changes?**:

It should not, as it assumes linear defaults if no raid type is specified.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

Changes are tested against both unit and integration tests.

**Any additional information for your reviewer?** :

The original issue brought up that care should be taken when allowing extra arguments to the `lvcreate` command, but I didn't see a history of sanitizing the input to the CLI commands anywhere else, so I'm not sure if more care should be given to that specific option. It seems that the underlying command runner for go does not spawn it in a shell, so it might not be necessary.

I had to update the base docker image to bring in a newer version of LVM2 that supports both dm integrity and raid options. I used the first version of alpine past the previous base image version that supported the needed arguments, but let me know if you would prefer to just update to the newest version available instead.

Also, documentation needs to be updated to explain the changes.

**Checklist:**
- [x] Fixes #164 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [x] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
