### PR TITLE
refactor(lvm): continue refactoring of lvm command calling convention

### DIFF
--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -29,9 +29,9 @@ then
   export KUBECONFIG="${HOME}/.kube/config"
 fi
 
-# systemid for the testing environment. The kubernetes host machine will serve as the foreign lvm system.
-LVM_SYSTEMID="openebs-ci-test-system"
-LVM_CONFIG="global{system_id_source=lvmlocal}local{system_id=${LVM_SYSTEMID}}"
+# foreign systemid for the testing environment.
+FOREIGN_LVM_SYSTEMID="openebs-ci-test-system"
+FOREIGN_LVM_CONFIG="global{system_id_source=lvmlocal}local{system_id=${FOREIGN_LVM_SYSTEMID}}"
 
 # Clean up generated resources for successive tests.
 cleanup_loopdev() {
@@ -54,7 +54,7 @@ cleanup_lvmvg() {
 cleanup_foreign_lvmvg() {
   if [ -f /tmp/openebs_ci_foreign_disk.img ]
   then
-    sudo vgremove foreign_lvmvg --config="${LVM_CONFIG}" -y || true
+    sudo vgremove foreign_lvmvg --config="${FOREIGN_LVM_CONFIG}" -y || true
     rm /tmp/openebs_ci_foreign_disk.img
   fi
   cleanup_loopdev
@@ -91,7 +91,7 @@ cleanup_foreign_lvmvg
 truncate -s 1024G /tmp/openebs_ci_foreign_disk.img
 foreign_disk="$(sudo losetup -f /tmp/openebs_ci_foreign_disk.img --show)"
 sudo pvcreate "${foreign_disk}"
-sudo vgcreate foreign_lvmvg "${foreign_disk}" --systemid="${LVM_SYSTEMID}"
+sudo vgcreate foreign_lvmvg "${foreign_disk}" --config="${FOREIGN_LVM_CONFIG}"
 
 # install snapshot and thin volume module for lvm
 sudo modprobe dm-snapshot


### PR DESCRIPTION
The number of this branch refers to pull request #250.

**Why is this PR required? What issue does it fix?**:
The calling convention of lvm commands in pkg/lvm/lvm_util.go should all follow the same format, following issue #247. This reduces the impact of unforseen (non-critical) warnings being printed to the STDERR output stream, which CombinedOutput mixes with STDOUT.

**What this PR does?**:
Refactor all occurrences of Commands using CombinedOutput with an lvm command to use RunCommandSplit, a function which splits the STDERR and STDOUT streams into separate return values. Additionally, RunCommandSplit prints any STDERR messages to the log as a warning so that these messages aren't lost.

Additionally, this PR refactors some changes in ci/ci-test.sh that were added in pull #250. During ci tests of these changes, I found that the tests were failing for an unknown reason. A small patch has been applied to ci/ci-test.sh which may help resolve that issue on some machines.

**Does this PR require any upgrade changes?**:
Most likely not.

**If the changes in this PR are manually verified, list down the scenarios covered:**:
No manual verification. The refactors in this PR are a follow-up to issue #247.

**Any additional information for your reviewer?** :
This PR is a continuation of pull request #250.


**Checklist:**
- [x] Fixes #247
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated? -- A change log has not been provided for this PR at this time.
- [ ] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: