### PR TITLE
fix(charts): remove extra hyphen to make helm linter pass

### DIFF
--- a/deploy/helm/charts/templates/rbac.yaml
+++ b/deploy/helm/charts/templates/rbac.yaml
@@ -123,7 +123,8 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 {{- end }}
-{{- if .Values.serviceAccount.lvmNode.create -}}
+
+{{- if .Values.serviceAccount.lvmNode.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:

Template `deploy/helm/charts/templates/rbac.yaml` is making `helm lint` to fail.

**What this PR does?**:

The hyphen at the end of the closing brackets is responsible for chomping all the whitespaces after the brackets.
Thus, a previous YAML separator gets into the same line as the `apiVersion` element from the resource enable by the `if` statement.

**Does this PR require any upgrade changes?**:

No.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

```bash
cd deploy/helm/charts
helm lint .
```

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #271
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: