### PR TITLE
fix(helm): remove useless crd.enableInstall variable

### DIFF
--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -165,7 +165,6 @@ lvmPlugin:
 role: openebs-lvm
 
 crd:
-  enableInstall: true
   # Specify installation of the kubernetes-csi volume snapshot CRDs if your Kubernetes distribution
   # or another storage operator already manages them.
   volumeSnapshot: true


### PR DESCRIPTION
**What this PR does?**:

remove the useless `crd.enableInstall` variable which has no reference in helm chart.

**Does this PR require any upgrade changes?**:

no 