### PR TITLE
feat(charts): disable hostNetwork on node plugin

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 1.4.0
+version: 1.4.1
 appVersion: 1.4.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: https://openebs.io/

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -30,7 +30,7 @@ spec:
       priorityClassName: {{ template "lvmlocalpv.lvmNode.priorityClassName" . }}
 {{- end }}
       serviceAccountName: {{ .Values.serviceAccount.lvmNode.name }}
-      hostNetwork: true
+      hostNetwork: {{ .Values.lvmNode.hostNetwork }}
       containers:
         - name: {{ .Values.lvmNode.driverRegistrar.name }}
           image: "{{ .Values.lvmNode.driverRegistrar.image.registry }}{{ .Values.lvmNode.driverRegistrar.image.repository }}:{{ .Values.lvmNode.driverRegistrar.image.tag }}"

--- a/deploy/helm/charts/templates/psp.yaml
+++ b/deploy/helm/charts/templates/psp.yaml
@@ -10,7 +10,7 @@ spec:
   allowPrivilegeEscalation: true
   allowedCapabilities: ['*']
   volumes: ['*']
-  hostNetwork: true
+  hostNetwork: {{ .Values.lvmNode.hostNetwork}}
   hostIPC: true
   hostPID: true
   runAsUser:

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -61,6 +61,8 @@ lvmNode:
     # Configure the maximum number of queries allowed after
     # accounting for rolled over qps from previous seconds.
     burst: 0
+  # Disable or enable the use of hostNetwork for the lvm node daemonset.
+  hostNetwork: false
 
 
 # lvmController contains the configurables for

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -1633,7 +1633,6 @@ spec:
     spec:
       priorityClassName: openebs-lvm-localpv-csi-node-critical
       serviceAccountName: openebs-lvm-node-sa
-      hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0

--- a/deploy/yamls/lvm-driver.yaml
+++ b/deploy/yamls/lvm-driver.yaml
@@ -1197,7 +1197,6 @@ spec:
     spec:
       priorityClassName: openebs-lvm-localpv-csi-node-critical
       serviceAccountName: openebs-lvm-node-sa
-      hostNetwork: true
       containers:
         - name: csi-node-driver-registrar
           image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0


### PR DESCRIPTION
Resolves #274 

This allows hostNetwork on lvm-csi-node to be configurable, with default as false.