### PR TITLE
fix: crds getting removed on helm upgrades

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -4,3 +4,4 @@ target-branch: develop
 chart-dirs:
   - deploy/helm
 helm-extra-args: --timeout=500s
+validate-maintainers: false

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 1.5.0
+version: 1.5.1
 appVersion: 1.5.0
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: https://openebs.io/
@@ -16,11 +16,4 @@ sources:
 - https://github.com/openebs/lvm-localpv
 dependencies:
   - name: crds
-    version: "1.5.0"
-maintainers:
-  - name: prateekpandey14
-    email: prateek.pandey@mayadata.io
-  - name: pawanpraka1
-    email: pawan@mayadata.io
-  - name: iyashu
-    email: yashpal.c1995@gmail.com
+    version: "1.5.1"

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -16,5 +16,5 @@ sources:
 - https://github.com/openebs/lvm-localpv
 dependencies:
   - name: crds
-    version: "1.5.1"
+    version: 1.5.1
     condition: crds.enabled

--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -17,3 +17,4 @@ sources:
 dependencies:
   - name: crds
     version: "1.5.1"
+    condition: crds.enabled

--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -101,7 +101,7 @@ helm install openebs-lvmlocalpv openebs-lvmlocalpv/lvm-localpv --namespace opene
 | `lvmPlugin.image.registry`                          | Registry for openebs-lvm-plugin image                                            | `""`                                    |
 | `lvmPlugin.image.repository`                        | Image repository for openebs-lvm-plugin                                          | `openebs/lvm-driver`                    |
 | `lvmPlugin.image.pullPolicy`                        | Image pull policy for openebs-lvm-plugin                                         | `IfNotPresent`                          |
-| `lvmPlugin.image.tag`                               | Image tag for openebs-lvm-plugin                                                 | `1.3.0`                                 |
+| `lvmPlugin.image.tag`                               | Image tag for openebs-lvm-plugin                                                 | `1.5.0`                                 |
 | `lvmPlugin.metricsPort`                             | The TCP port number used for exposing lvm-metrics                                | `9500`                                  |
 | `lvmPlugin.allowedTopologies`                       | The comma seperated list of allowed node topologies                              | `kubernetes.io/hostname,`               |
 | `lvmNode.driverRegistrar.image.registry`            | Registry for csi-node-driver-registrar image                                     | `registry.k8s.io/`                      |

--- a/deploy/helm/charts/charts/crds/Chart.yaml
+++ b/deploy/helm/charts/charts/crds/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: crds
-version: 1.5.0
+version: 1.5.1
 description: A Helm chart that collects CustomResourceDefinitions (CRDs) from lvm-localpv.

--- a/deploy/helm/charts/charts/crds/templates/_helpers.tpl
+++ b/deploy/helm/charts/charts/crds/templates/_helpers.tpl
@@ -1,20 +1,4 @@
-{{/*
-    This returns a "1" if the CRD is absent in the cluster
-    Usage:
-      {{- if (include "crdIsAbsent" (list <crd-name>)) -}}
-      # CRD Yaml
-      {{- end -}}
-*/}}
-{{- define "crdIsAbsent" -}}
-    {{- $crdName := index . 0 -}}
-    {{- $crd := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" $crdName -}}
-    {{- $output := "1" -}}
-    {{- if $crd -}}
-        {{- $output = "" -}}
-    {{- end -}}
-
-    {{- $output -}}
-{{- end -}}
+{{/* vim: set filetype=mustache: */}}
 
 {{/*
     Adds extra annotations to CRDs. This targets two scenarios: preventing CRD recycling in case

--- a/deploy/helm/charts/charts/crds/templates/_helpers.tpl
+++ b/deploy/helm/charts/charts/crds/templates/_helpers.tpl
@@ -15,3 +15,20 @@
 
     {{- $output -}}
 {{- end -}}
+
+{{/*
+    Adds extra annotations to CRDs. This targets two scenarios: preventing CRD recycling in case
+    the chart is removed; and adding custom annotations.
+    NOTE: This function assumes the element `metadata.annotations` already exists.
+    Usage:
+      {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
+*/}}
+
+{{- define "crds.extraAnnotations" -}}
+{{- if .keep -}}
+helm.sh/resource-policy: keep
+{{ end }}
+{{- with .annotations }}
+  {{- toYaml . }}
+{{- end }}
+{{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot-class.yaml
+++ b/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot-class.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshotclasses.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshotclasses.snapshot.storage.k8s.io
 spec:
@@ -148,5 +147,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot-content.yaml
+++ b/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot-content.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshotcontents.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshotcontents.snapshot.storage.k8s.io
 spec:
@@ -486,5 +485,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/csi-volume-snapshot.yaml
@@ -1,12 +1,11 @@
 {{- if .Values.csi.volumeSnapshots.enabled -}}
-{{- $crdName := "volumesnapshots.snapshot.storage.k8s.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-csi/external-snapshotter/pull/814
     controller-gen.kubebuilder.io/version: v0.11.3
+    {{- include "crds.extraAnnotations" .Values.csi.volumeSnapshots | nindent 4 }}
   creationTimestamp: null
   name: volumesnapshots.snapshot.storage.k8s.io
 spec:
@@ -388,5 +387,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/lvmnode.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmnode.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
+    {{- include "crds.extraAnnotations" .Values.lvmLocalPv | nindent 4 }}
   creationTimestamp: null
   name: lvmnodes.local.openebs.io
 spec:

--- a/deploy/helm/charts/charts/crds/templates/lvmnode.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmnode.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.lvmLocalPv.enabled -}}
-{{- $crdName := "lvmnodes.local.openebs.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 ##############################################
 ###########                       ############
 ###########     LVMNode CRD       ############
@@ -177,5 +175,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/lvmsnapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmsnapshot.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
+    {{- include "crds.extraAnnotations" .Values.lvmLocalPv | nindent 4 }}
   creationTimestamp: null
   name: lvmsnapshots.local.openebs.io
 spec:

--- a/deploy/helm/charts/charts/crds/templates/lvmsnapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmsnapshot.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.lvmLocalPv.enabled -}}
-{{- $crdName := "lvmsnapshots.local.openebs.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 ##############################################
 ###########                       ############
 ###########   LVMSnapshot CRD     ############
@@ -85,5 +83,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/templates/lvmvolume.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmvolume.yaml
@@ -17,6 +17,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.4.0
+    {{- include "crds.extraAnnotations" .Values.lvmLocalPv | nindent 4 }}
   creationTimestamp: null
   name: lvmvolumes.local.openebs.io
 spec:

--- a/deploy/helm/charts/charts/crds/templates/lvmvolume.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmvolume.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.lvmLocalPv.enabled -}}
-{{- $crdName := "lvmvolumes.local.openebs.io" -}}
-{{- if (include "crdIsAbsent" (list $crdName)) -}}
 ##############################################
 ###########                       ############
 ###########   LVMVolume CRD       ############
@@ -153,5 +151,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-{{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/charts/crds/values.yaml
+++ b/deploy/helm/charts/charts/crds/values.yaml
@@ -1,8 +1,12 @@
 lvmLocalPv:
   # Install lvm-localpv CRDs
   enabled: true
+  # Keep CRDs on chart uninstall
+  keep: true
 
 csi:
   volumeSnapshots:
     # Install Volume Snapshot CRDs
     enabled: true
+    # Keep CRDs on chart uninstall
+    keep: true

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -2,7 +2,7 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 release:
-  version: "1.5.0"
+  version: "1.5.1"
 
 imagePullSecrets:
 # - name: "image-pull-secret"
@@ -187,7 +187,11 @@ crds:
   lvmLocalPv:
     # Install lvm-localpv CRDs
     enabled: true
+    # Keep CRDs on chart uninstall
+    keep: true
   csi:
     volumeSnapshots:
       # Install Volume Snapshot CRDs
       enabled: true
+      # Keep CRDs on chart uninstall
+      keep: true


### PR DESCRIPTION
#### Why do we need this PR?

It was seen that on upgrade to 1.5.x the CRDs get removed causing the removal of CRs. This would prevent it.
It also adds annotations to let helm keep the CRDs on uninstall, which is configurable.