### PR TITLE
fix(localpv): ensure kubeletDir trailing slash

### DIFF
--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -136,3 +136,10 @@ Create the name of the priority class for csi controller plugin
 {{- printf "%s" .Values.lvmController.priorityClass.name | trunc 63 | trimSuffix "-" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Ensure that the path to kubelet ends with a slash
+*/}}
+{{- define "lvmlocalpv.lvmNode.kubeletDir" -}}
+{{- printf "%s/" (.Values.lvmNode.kubeletDir | trimSuffix "/") -}}
+{{- end }}

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -47,7 +47,7 @@ spec:
             - name: ADDRESS
               value: /plugin/csi.sock
             - name: DRIVER_REG_SOCK_PATH
-              value: {{ .Values.lvmNode.kubeletDir }}plugins/lvm-localpv/csi.sock
+              value: {{ printf "%s%s" (include "lvmlocalpv.lvmNode.kubeletDir" .) "plugins/lvm-localpv/csi.sock" | quote }}
             - name: KUBE_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -117,7 +117,7 @@ spec:
             - name: device-dir
               mountPath: /dev
             - name: pods-mount-dir
-              mountPath: {{ .Values.lvmNode.kubeletDir }}
+              mountPath: {{ include "lvmlocalpv.lvmNode.kubeletDir" . | quote }}
               # needed so that any mounts setup inside this container are
               # propagated back to the host machine.
               mountPropagation: "Bidirectional"
@@ -130,15 +130,15 @@ spec:
             type: Directory
         - name: registration-dir
           hostPath:
-            path: {{ .Values.lvmNode.kubeletDir }}plugins_registry/
+            path: {{ printf "%s%s" (include "lvmlocalpv.lvmNode.kubeletDir" .) "plugins_registry/" | quote }}
             type: DirectoryOrCreate
         - name: plugin-dir
           hostPath:
-            path: {{ .Values.lvmNode.kubeletDir }}plugins/lvm-localpv/
+            path: {{ printf "%s%s" (include "lvmlocalpv.lvmNode.kubeletDir" .) "plugins/lvm-localpv/" | quote }}
             type: DirectoryOrCreate
         - name: pods-mount-dir
           hostPath:
-            path: {{ .Values.lvmNode.kubeletDir }}
+            path: {{ include "lvmlocalpv.lvmNode.kubeletDir" . | quote }}
             type: Directory
 {{- if .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**: This PR avoids subtle problems when installing on microk8s or other k8s distributions with a different kubelet path. If the user types the path into the values file without a trailing slash, all the openebs pods would be running and even generate PVs and LVs, but no pods using the PVs would start because the CSI plugin was not installed correctly on the node.

**What this PR does?**: The lvm-node template is updated to ensure that there is always a slash between the kubeletDir value and subdirectories that are appended. Additionally, the paths are now quoted, in case they contain some characters that would cause problems when interpreting the rendered template as YAML.

**Does this PR require any upgrade changes?**: No. The user sets the same value, and the current values with trailing slashes produce the same output as before.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

`helm template . -s templates/lvm-node.yaml --set lvmNode.kubeletDir=/var/lib/kubelet/` and `helm template . -s templates/lvm-node.yaml --set lvmNode.kubeletDir=/var/lib/kubelet` now produce the same result.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: