### PR TITLE
test: thinpool auto-extend test

### DIFF
--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -81,14 +81,14 @@ cleanup() {
 
 # setup the lvm volume group to create the volume
 cleanup_lvmvg
-truncate -s 1024G /tmp/openebs_ci_disk.img
+truncate -s 100G /tmp/openebs_ci_disk.img
 disk="$(sudo losetup -f /tmp/openebs_ci_disk.img --show)"
 sudo pvcreate "${disk}"
 sudo vgcreate lvmvg "${disk}"
 
 # setup a foreign lvm to test
 cleanup_foreign_lvmvg
-truncate -s 1024G /tmp/openebs_ci_foreign_disk.img
+truncate -s 100G /tmp/openebs_ci_foreign_disk.img
 foreign_disk="$(sudo losetup -f /tmp/openebs_ci_foreign_disk.img --show)"
 sudo pvcreate "${foreign_disk}"
 sudo vgcreate foreign_lvmvg "${foreign_disk}" --config="${FOREIGN_LVM_CONFIG}"
@@ -96,6 +96,10 @@ sudo vgcreate foreign_lvmvg "${foreign_disk}" --config="${FOREIGN_LVM_CONFIG}"
 # install snapshot and thin volume module for lvm
 sudo modprobe dm-snapshot
 sudo modprobe dm_thin_pool
+
+# Set the configuration for thin pool autoextend in lvm.conf
+sudo sed -i '/^[^#]*thin_pool_autoextend_threshold/ s/= .*/= 50/' /etc/lvm/lvm.conf
+sudo sed -i '/^[^#]*thin_pool_autoextend_percent/ s/= .*/= 20/' /etc/lvm/lvm.conf
 
 # Prepare env for running BDD tests
 # Minikube is already running

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -94,6 +94,20 @@ func thinVolCreationTest() {
 	By("Deleting thinProvision storage class", deleteStorageClass)
 }
 
+func thinVolCapacityTest() {
+	By("Creating thinProvision storage class", createThinStorageClass)
+	By("creating and verifying PVC bound status", createAndVerifyPVC)
+	By("enabling monitoring on thinpool", enableThinpoolMonitoring)
+	By("Creating and deploying app pod", createDeployVerifyApp)
+	By("verifying thinpool auto-extended", VerifyThinpoolExtend)
+	By("verifying LVMVolume object", VerifyLVMVolume)
+	By("Deleting application deployment")
+	deleteAppDeployment(appName)
+	By("Deleting pvc")
+	deleteAndVerifyPVC(pvcName)
+	By("Deleting thinProvision storage class", deleteStorageClass)
+}
+
 func leakProtectionTest() {
 	By("Creating default storage class", createStorageClass)
 	ds := deleteNodeDaemonSet() // ensure that provisioning remains in pending state.
@@ -116,8 +130,9 @@ func leakProtectionTest() {
 }
 
 func volumeCreationTest() {
-	By("Running volume creation test", fsVolCreationTest)
+	By("Running filesystem volume creation test", fsVolCreationTest)
 	By("Running block volume creation test", blockVolCreationTest)
 	By("Running thin volume creation test", thinVolCreationTest)
+	By("Running thin volume capacity test", thinVolCapacityTest)
 	By("Running leak protection test", leakProtectionTest)
 }

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -65,15 +65,16 @@ var (
 	nodeDaemonSet        = "openebs-lvm-node"
 	controllerDeployment = "openebs-lvm-controller"
 
-	nsObj            *corev1.Namespace
-	scObj            *storagev1.StorageClass
-	deployObj        *appsv1.Deployment
-	pvcObj           *corev1.PersistentVolumeClaim
-	appPod           *corev1.PodList
-	accessModes      = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
-	capacity         = "5368709120" // 5Gi
-	KubeConfigPath   string
-	OpenEBSNamespace string
+	nsObj             *corev1.Namespace
+	scObj             *storagev1.StorageClass
+	deployObj         *appsv1.Deployment
+	pvcObj            *corev1.PersistentVolumeClaim
+	appPod            *corev1.PodList
+	accessModes       = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
+	capacity          = "5368709120" // 5Gi
+	expanded_capacity = "6442450944" // 6Gi
+	KubeConfigPath    string
+	OpenEBSNamespace  string
 )
 
 func init() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -19,6 +19,8 @@ package tests
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -705,4 +707,70 @@ func createNodeDaemonSet(ds *appsv1.DaemonSet) {
 	gomega.Expect(err).To(
 		gomega.BeNil(),
 		"creating node plugin daemonset %v", nodeDaemonSet)
+}
+
+// enable the monitoring on thinpool created for test, on local node which
+// is part of single node cluster.
+func enableThinpoolMonitoring() {
+	lv := VOLGROUP + "/" + pvcObj.Spec.VolumeName
+
+	args := []string{
+		"lvdisplay", "--columns",
+		"--options", "pool_lv",
+		"--noheadings",
+		lv,
+	}
+	stdout, _, err := execAtLocal("sudo", nil, args...)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "display LV")
+	gomega.Expect(strings.TrimSpace(string(stdout))).To(gomega.Not(gomega.Equal("")), "get thinpool LV")
+
+	thinpool := VOLGROUP + "/" + strings.TrimSpace(string(stdout))
+
+	args = []string{
+		"lvchange",
+		"--monitor", "y",
+		thinpool,
+	}
+
+	_, _, err = execAtLocal("sudo", nil, args...)
+	gomega.Expect(err).To(gomega.BeNil(), "run lvchange command")
+}
+
+// verify that the thinpool has extended in capacity to an expected size.
+func VerifyThinpoolExtend() {
+	expect_size, _ := strconv.ParseInt(expanded_capacity, 10, 64)
+	lv := VOLGROUP + "/" + pvcObj.Spec.VolumeName
+
+	args := []string{
+		"lvdisplay", "--columns",
+		"--options", "pool_lv",
+		"--noheadings",
+		lv,
+	}
+
+	//stdout will contain the pool name
+	stdout, _, err := execAtLocal("sudo", nil, args...)
+	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "display LV")
+	gomega.Expect(strings.TrimSpace(string(stdout))).To(gomega.Not(gomega.Equal("")), "get thinpool LV")
+
+	thinpool := VOLGROUP + "/" + strings.TrimSpace(string(stdout))
+
+	args = []string{
+		"lvdisplay", "--columns",
+		"--options", "lv_size",
+		"--units", "b",
+		"--noheadings",
+		thinpool,
+	}
+
+	// stdout will contain the size
+	stdout, _, err = execAtLocal("sudo", nil, args...)
+	gomega.Expect(err).To(gomega.BeNil(), "display thinpool LV")
+
+	// Remove unit suffix from the size.
+	size_str := strings.TrimSuffix(strings.TrimSpace(string(stdout)), "B")
+	// This expectation is a factor of the lvm.conf settings we do from ci-test.sh
+	// and the original volume size.
+	size_int64, _ := strconv.ParseInt(size_str, 10, 64)
+	gomega.Expect(size_int64).To(gomega.Equal(expect_size))
 }


### PR DESCRIPTION
This change adds a test that verifies a thinpool auto-extends in size as configured in the lvm.conf file.

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
This adds a test for verifying thinpool auto-extend.

**What this PR does?**:
Adds a new test which fills up the LVM logical volume to a certain capacity so that
auto-extend of underlying thinpool kicks in.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
