### PR TITLE
fix(chart): revert env OPENEBS_NAMESPACE to LVM_NAMESPACE for v1.6.x

### DIFF
--- a/deploy/helm/charts/Chart.yaml
+++ b/deploy/helm/charts/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: lvm-localpv
 description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-version: 1.6.1
+version: 1.6.2
 appVersion: 1.6.1
 icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
 home: https://openebs.io/
@@ -16,5 +16,5 @@ sources:
 - https://github.com/openebs/lvm-localpv
 dependencies:
   - name: crds
-    version: 1.6.1
+    version: 1.6.2
     condition: crds.enabled

--- a/deploy/helm/charts/charts/crds/Chart.yaml
+++ b/deploy/helm/charts/charts/crds/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v2
 name: crds
-version: 1.6.1
+version: 1.6.2
 description: A Helm chart that collects CustomResourceDefinitions (CRDs) from lvm-localpv.

--- a/deploy/helm/charts/templates/lvm-controller.yaml
+++ b/deploy/helm/charts/templates/lvm-controller.yaml
@@ -109,7 +109,7 @@ spec:
               value: controller
             - name: OPENEBS_CSI_ENDPOINT
               value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-            - name: OPENEBS_NAMESPACE
+            - name: LVM_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -91,7 +91,7 @@ spec:
               value: unix:///plugin/csi.sock
             - name: OPENEBS_NODE_DRIVER
               value: agent
-            - name: OPENEBS_NAMESPACE
+            - name: LVM_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace


### PR DESCRIPTION
The env LVM_NAMESPACE was changed to OPENEBS_NAMESPACE on the develop branch as a part of https://github.com/openebs/lvm-localpv/pull/324. This change breaks v1.6.x.

Need to investigate if it breaks develop as well.