### PR TITLE
revert: remove chart v1.6.1 from helm registry index

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,31 +2,6 @@ apiVersion: v1
 entries:
   lvm-localpv:
   - apiVersion: v2
-    appVersion: 1.6.1
-    created: "2024-09-17T12:58:11.817479903Z"
-    dependencies:
-    - condition: crds.enabled
-      name: crds
-      repository: ""
-      version: 1.6.1
-    description: CSI Driver for dynamic provisioning of LVM Persistent Local Volumes.
-    digest: 31c6c36f466ab8959a0a93fa5d5e77417c02a0e222e71924e512d4c10076b0b9
-    home: https://openebs.io/
-    icon: https://raw.githubusercontent.com/cncf/artwork/master/projects/openebs/icon/color/openebs-icon-color.png
-    keywords:
-    - cloud-native-storage
-    - block-storage
-    - filesystem
-    - LVM
-    - Local Persistent Volumes
-    - storage
-    name: lvm-localpv
-    sources:
-    - https://github.com/openebs/lvm-localpv
-    urls:
-    - https://github.com/openebs/lvm-localpv/releases/download/lvm-localpv-1.6.1/lvm-localpv-1.6.1.tgz
-    version: 1.6.1
-  - apiVersion: v2
     appVersion: 1.6.0
     created: "2024-07-05T10:35:43.197477643Z"
     dependencies:


### PR DESCRIPTION
The v1.6.1 helm chart has a bug which results in the LocalPV LVM node driver DaemonSet Pods to crash.
The v1.6.1 chart has been removed from the release assets. Please use the [v1.6.2](https://github.com/openebs/lvm-localpv/releases/tag/lvm-localpv-1.6.2) chart instead.

Ref:
- https://github.com/openebs/lvm-localpv/pull/324
- https://github.com/openebs/lvm-localpv/pull/333