### PR TITLE
Fix: Disable lvm archive

### DIFF
--- a/buildscripts/lvm-driver/Dockerfile
+++ b/buildscripts/lvm-driver/Dockerfile
@@ -17,6 +17,9 @@ RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
 RUN apk add --no-cache btrfs-progs xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates libc6-compat
 
+# Disable lvm archiving
+RUN sed -i -r -e '/^\s*#?\s*archive\s*=/s/^.*$/        archive = 0/' /etc/lvm/lvm.conf
+
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL
 ARG DBUILD_SITE_URL

--- a/buildscripts/lvm-driver/Dockerfile.buildx
+++ b/buildscripts/lvm-driver/Dockerfile.buildx
@@ -46,6 +46,9 @@ RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
 RUN apk add --no-cache btrfs-progs xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates libc6-compat
 
+# Disable lvm archiving
+RUN sed -i -r -e '/^\s*#?\s*archive\s*=/s/^.*$/        archive = 0/' /etc/lvm/lvm.conf
+
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL
 ARG DBUILD_SITE_URL

--- a/changelogs/unreleased/236-frasmarco
+++ b/changelogs/unreleased/236-frasmarco
@@ -1,0 +1,1 @@
+Disable lvm archive in order to limit space usage when creating **lots** of volumes


### PR DESCRIPTION
## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:
This PR resolves #236 disabling lvm archiving which is enabled by default in Alpine

**What this PR does?**:
changes from 1 to 0 the archive setting in /etc/lvm/lvm.conf via sed in the Docker build phase

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Verify that archive dir /etc/lvm/archive remains empty after lv provisioning

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #236
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [x] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

Signed-off-by: Marco Frassinelli <fras.marco@gmail.com>