### PR TITLE
build: a number of fixes on Makefile and nix-shell

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -49,6 +49,11 @@ jobs:
           go-version: 1.19.9
           cache: false
 
+      - name: Set go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
       - name: Unit test
         run: make test
 
@@ -77,6 +82,11 @@ jobs:
           go-version: 1.19.9
           cache: false
 
+      - name: Set go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
       - name: Setup Minikube-Kubernetes
         uses: medyagh/setup-minikube@latest
         with:
@@ -99,7 +109,7 @@ jobs:
         run: ./ci/ci-test.sh
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4  
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./tests/bdd_coverage.txt

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,6 +29,11 @@ jobs:
           go-version: 1.19.9
           cache: false
 
+      - name: Set go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
       - name: Lint Check
         uses: golangci/golangci-lint-action@v4
         with:
@@ -71,6 +76,11 @@ jobs:
           go-version: 1.19.9
           cache: false
 
+      - name: Set go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
       - name: Unit test
         run: make test
 
@@ -99,8 +109,13 @@ jobs:
           go-version: 1.19.9
           cache: false
 
+      - name: Set go env
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> $GITHUB_ENV
+          echo "GOCACHE=$(go env GOCACHE)" >> $GITHUB_ENV
+
       - name: Build images locally
-        run: make lvm-driver-image || exit 1;
+        run: make lvm-driver-image
 
       - name: Setup Minikube-Kubernetes
         uses: medyagh/setup-minikube@latest
@@ -125,7 +140,7 @@ jobs:
         run: ./ci/ci-test.sh
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v4  
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./tests/bdd_coverage.txt

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tags
 *.idea
 *.test
 coverage.txt
+/tests/bdd_coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ clean:
 	@echo "--> Cleaning Directory" ;
 	go clean -testcache
 	rm -rf bin
+	CLEANUP_ONLY=1 ./ci/ci-test.sh
 	chmod -R u+w ${GOPATH}/bin/${CSI_DRIVER} 2>/dev/null || true
 	chmod -R u+w ${GOPATH}/pkg/* 2>/dev/null || true
 	rm -rf ${GOPATH}/bin/${CSI_DRIVER}

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,7 @@ install-golangci-lint:
 
 .PHONY: controller-gen
 controller-gen:
-	TMP_DIR=$(shell mktemp -d) && cd $$TMP_DIR && go mod init tmp && go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0 && rm -rf $$TMP_DIR;
+	@go install -mod=mod sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.0
 
 # SRC_PKG is the path of code files
 SRC_PKG := github.com/openebs/lvm-localpv/pkg

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods \
 EXTERNAL_TOOLS=\
 	golang.org/x/tools/cmd/cover \
 	golang.org/x/lint/golint \
-	github.com/axw/gocov/gocov \
+	github.com/axw/gocov/gocov@v1.1 \
 	github.com/matm/gocov-html/cmd/gocov-html \
 	github.com/onsi/ginkgo/ginkgo \
-	github.com/onsi/gomega/...
+	github.com/onsi/gomega/...@v1.35
 
 # The images can be pushed to any docker/image registeries
 # like docker hub, quay. The registries are specified in
@@ -86,6 +86,8 @@ clean:
 	@echo "--> Cleaning Directory" ;
 	go clean -testcache
 	rm -rf bin
+	chmod -R u+w ${GOPATH}/bin/${CSI_DRIVER} 2>/dev/null || true
+	chmod -R u+w ${GOPATH}/pkg/* 2>/dev/null || true
 	rm -rf ${GOPATH}/bin/${CSI_DRIVER}
 	rm -rf ${GOPATH}/pkg/*
 
@@ -119,7 +121,10 @@ verify-deps: deps
 bootstrap: controller-gen install-golangci-lint
 	@for tool in  $(EXTERNAL_TOOLS) ; do \
 		echo "+ Installing $$tool" ; \
-		cd && GO111MODULE=on go install $$tool@latest; \
+		if ! echo $$tool | grep "@"; then \
+			tool=$$tool@latest ; \
+		fi ; \
+		GO111MODULE=on go install $$tool; \
 	done
 
 ## golangci-lint tool used to check linting tools in codebase
@@ -130,7 +135,7 @@ bootstrap: controller-gen install-golangci-lint
 ## Install golangci-lint only if tool doesn't exist in system
 .PHONY: install-golangci-lint
 install-golangci-lint:
-	$(if $(shell which golangci-lint), echo "golangci-lint already exist in system", (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b "${GOPATH}/bin" v1.56.2))
+	$(if $(shell which golangci-lint), echo "golangci-lint already exist in system", (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "${GOPATH}/bin" v1.56.2))
 
 .PHONY: controller-gen
 controller-gen:
@@ -222,15 +227,8 @@ lvm-driver-image: lvm-driver
 	@echo "+ Generating ${CSI_DRIVER} image"
 	@echo "--------------------------------"
 	@cp bin/${CSI_DRIVER}/${CSI_DRIVER} buildscripts/${CSI_DRIVER}/
-	cd buildscripts/${CSI_DRIVER} && sudo docker build -t ${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG} ${DBUILD_ARGS} . && sudo docker tag ${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG} quay.io/${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG}
+	cd buildscripts/${CSI_DRIVER} && docker build -t ${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG} ${DBUILD_ARGS} . && docker tag ${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG} quay.io/${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG}
 	@rm buildscripts/${CSI_DRIVER}/${CSI_DRIVER}
-
-.PHONY: ansible-runner-image
-ansible-runner-image:
-	@echo "------------------"
-	@echo "--> Build ansible-runner image for lvm-localpv e2e-tests" 
-	@echo "------------------"
-	sudo docker build . -f e2e-tests/Dockerfile -t ${IMAGE_ORG}/lvm-localpv-e2e:ci
 
 .PHONY: ci
 ci:

--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -25,9 +25,9 @@ DIR="$( cd -P "$( dirname "$SOURCE" )/../" && pwd )"
 cd "$DIR"
 
 # Get the git commit
-if [ -f $GOPATH/src/github.com/openebs/lvm-localpv/GITCOMMIT ];
+if [ -f "$GOPATH"/src/github.com/openebs/lvm-localpv/GITCOMMIT ];
 then
-    GIT_COMMIT="$(cat $GOPATH/src/github.com/openebs/lvm-localpv/GITCOMMIT)"
+    GIT_COMMIT="$(cat "$GOPATH"/src/github.com/openebs/lvm-localpv/GITCOMMIT)"
 else
     GIT_COMMIT="$(git rev-parse HEAD)"
 fi
@@ -38,9 +38,9 @@ if [[ -n "$RELEASE_TAG" ]] && [[ $RELEASE_TAG != *"RC"* ]]; then
 fi
 
 CURRENT_BRANCH=""
-if [ -z ${BRANCH} ];
+if [ -z "${BRANCH}" ];
 then
-  CURRENT_BRANCH=$(git branch | grep \* | cut -d ' ' -f2)
+  CURRENT_BRANCH=$(git branch --show-current)
 else
   CURRENT_BRANCH=${BRANCH}
 fi
@@ -49,19 +49,18 @@ fi
 if [ -n "$RELEASE_TAG" ]; then
 	VERSION="$RELEASE_TAG"
 else
-	BUILDDATE=`date +%m-%d-%Y`
+	BUILDDATE=$(date +%m-%d-%Y)
 	SHORT_COMMIT="$(git rev-parse --short HEAD)"
 	VERSION="$CURRENT_BRANCH-$SHORT_COMMIT:$BUILDDATE"
 fi
 
 echo -e "\nbuilding the LVM Driver version :- $VERSION\n"
 
-VERSION_META="$(cat $PWD/BUILDMETA)"
+VERSION_META="$(cat "$PWD"/BUILDMETA)"
 
 # Determine the arch/os combos we're building for
 UNAME=$(uname)
-ARCH=$(uname -m)
-if [ "$UNAME" != "Linux" -a "$UNAME" != "Darwin" ] ; then
+if [ "$UNAME" != "Linux" ] && [ "$UNAME" != "Darwin" ] ; then
     echo "Sorry, this OS is not supported yet."
     exit 1
 fi
@@ -80,8 +79,8 @@ fi
 
 # Delete the old dir
 echo "==> Removing old directory..."
-rm -rf bin/${PNAME}/*
-mkdir -p bin/${PNAME}/
+rm -rf bin/"${PNAME}"/*
+mkdir -p bin/"${PNAME}"/
 
 XC_OS=$(go env GOOS)
 XC_ARCH=$(go env GOARCH)
@@ -89,19 +88,23 @@ XC_ARCH=$(go env GOARCH)
 # Build!
 echo "==> Building ${CTLNAME} using $(go version)... "
 
+if [ -n "$IN_NIX_SHELL" ]; then
+    MAYBE_STATIC="-linkmode external -extldflags -static"
+fi
+
 GOOS="${XC_OS}"
 GOARCH="${XC_ARCH}"
-output_name="bin/${PNAME}/"$GOOS"_"$GOARCH"/"$CTLNAME
+output_name=bin/"$PNAME"/"$GOOS"_"$GOARCH"/"$CTLNAME"
 
-if [ $GOOS = "windows" ]; then
+if [ "$GOOS" = "windows" ]; then
     output_name+='.exe'
 fi
-env GOOS=$GOOS GOARCH=$GOARCH go build -ldflags \
+env GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags \
     "-X github.com/openebs/lvm-localpv/pkg/version.GitCommit=${GIT_COMMIT} \
     -X main.CtlName='${CTLNAME}' \
     -X github.com/openebs/lvm-localpv/pkg/version.Version=${VERSION} \
-    -X github.com/openebs/lvm-localpv/pkg/version.VersionMeta=${VERSION_META}"\
-    -o $output_name\
+    -X github.com/openebs/lvm-localpv/pkg/version.VersionMeta=${VERSION_META}" \
+    -o "$output_name" \
     ./cmd
 
 echo ""
@@ -110,24 +113,26 @@ echo ""
 GOPATH=${GOPATH:-$(go env GOPATH)}
 case $(uname) in
     CYGWIN*)
-        GOPATH="$(cygpath $GOPATH)"
+        GOPATH="$(cygpath "$GOPATH")"
         ;;
 esac
 OLDIFS=$IFS
-IFS=: MAIN_GOPATH=($GOPATH)
+IFS=:
+read -r -a SPLIT_GOPATHS <<< "$GOPATH"
 IFS=$OLDIFS
+MAIN_GOPATH=${SPLIT_GOPATHS[0]}
 
 # Create the gopath bin if not already available
-mkdir -p ${MAIN_GOPATH}/bin/
+mkdir -p "${MAIN_GOPATH}"/bin/
 
 # Copy our OS/Arch to the bin/ directory
 DEV_PLATFORM="./bin/${PNAME}/$(go env GOOS)_$(go env GOARCH)"
-for F in $(find ${DEV_PLATFORM} -mindepth 1 -maxdepth 1 -type f); do
-    cp ${F} bin/${PNAME}/
-    cp ${F} ${MAIN_GOPATH}/bin/
-done
+find "${DEV_PLATFORM}" -mindepth 1 -maxdepth 1 -type f \
+    -exec cp {} "bin/${PNAME}/" \; \
+    -exec cp {} "${MAIN_GOPATH}/bin/" \;
+
 
 # Done!
 echo
 echo "==> Results:"
-ls -hl bin/${PNAME}/
+ls -hl bin/"${PNAME}"/

--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -88,10 +88,6 @@ XC_ARCH=$(go env GOARCH)
 # Build!
 echo "==> Building ${CTLNAME} using $(go version)... "
 
-if [ -n "$IN_NIX_SHELL" ]; then
-    MAYBE_STATIC="-linkmode external -extldflags -static"
-fi
-
 GOOS="${XC_OS}"
 GOARCH="${XC_ARCH}"
 output_name=bin/"$PNAME"/"$GOOS"_"$GOARCH"/"$CTLNAME"
@@ -99,9 +95,15 @@ output_name=bin/"$PNAME"/"$GOOS"_"$GOARCH"/"$CTLNAME"
 if [ "$GOOS" = "windows" ]; then
     output_name+='.exe'
 fi
-env GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags \
+
+if command -v musl-gcc; then
+    CC="musl-gcc"
+fi
+
+env CC="$CC" GOOS="$GOOS" GOARCH="$GOARCH" go build -ldflags \
     "-X github.com/openebs/lvm-localpv/pkg/version.GitCommit=${GIT_COMMIT} \
     -X main.CtlName='${CTLNAME}' \
+    -linkmode external -extldflags -static \
     -X github.com/openebs/lvm-localpv/pkg/version.Version=${VERSION} \
     -X github.com/openebs/lvm-localpv/pkg/version.VersionMeta=${VERSION_META}" \
     -o "$output_name" \

--- a/buildscripts/lvm-driver/Dockerfile.buildx
+++ b/buildscripts/lvm-driver/Dockerfile.buildx
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.9 as build
+FROM golang:1.19.9 AS build
 
 ARG BRANCH
 ARG RELEASE_TAG
@@ -34,7 +34,7 @@ WORKDIR /go/src/github.com/openebs/lvm-localpv/
 RUN apt-get update && apt-get install -y make git
 
 COPY go.mod go.sum ./
-# Get dependancies - will also be cached if we won't change mod/sum
+# Get dependencies - will also be cached if we won't change mod/sum
 RUN go mod download
 
 COPY . .

--- a/buildscripts/lvm-driver/Dockerfile.buildx
+++ b/buildscripts/lvm-driver/Dockerfile.buildx
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.9 AS build
+FROM golang:1.19.9-alpine AS build
 
 ARG BRANCH
 ARG RELEASE_TAG
@@ -31,7 +31,7 @@ ENV GO111MODULE=on \
 
 WORKDIR /go/src/github.com/openebs/lvm-localpv/
 
-RUN apt-get update && apt-get install -y make git
+RUN apk add make git bash gcc musl-dev
 
 COPY go.mod go.sum ./
 # Get dependencies - will also be cached if we won't change mod/sum
@@ -44,7 +44,7 @@ RUN make buildx.csi-driver
 FROM alpine:3.18.4
 RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
 RUN apk add --no-cache btrfs-progs xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
-RUN apk add --no-cache ca-certificates libc6-compat
+RUN apk add --no-cache ca-certificates
 
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL

--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -20,7 +20,7 @@ CRDS_TO_DELETE_ON_CLEANUP="lvmnodes.local.openebs.io lvmsnapshots.local.openebs.
 
 # Clean up generated resources for successive tests.
 cleanup_loopdev() {
-  sudo losetup -l | grep '(deleted)' | awk '{print $1}' \
+  losetup -l | grep '(deleted)' | awk '{print $1}' \
     | while IFS= read -r disk
       do
         sudo losetup -d "${disk}"
@@ -36,25 +36,41 @@ cleanup_foreign_lvmvg() {
   cleanup_loopdev
 }
 
+# Clean up loop devices and vgs created by the ginkgo lvm_utils.go
+cleanup_ginkgo_loop_lvm() {
+  for device in $(losetup -l -J | jq -r '.loopdevices[]|select(."back-file" | startswith("/tmp/openebs_lvm_localpv_disk_"))' | jq -r '.name'); do
+    echo "Found stale loop device: $device"
+
+    sudo "$(which vgremove)" -y --select="pv_name=$device" || :
+    sudo losetup -d "$device" 2>/dev/null || :
+  done
+}
+
 cleanup() {
   set +e
 
   echo "Cleaning up test resources"
 
   cleanup_foreign_lvmvg
+  cleanup_ginkgo_loop_lvm
 
-  kubectl delete pvc -n "$OPENEBS_NAMESPACE" lvmpv-pvc
-  kubectl delete -f "${SNAP_CLASS}"
+  if kubectl get nodes 2>/dev/null; then
+    kubectl delete pvc -n "$OPENEBS_NAMESPACE" lvmpv-pvc
+    kubectl delete -f "${SNAP_CLASS}"
 
-  helm uninstall lvm-localpv -n "$OPENEBS_NAMESPACE" || true
-  # shellcheck disable=SC2086
-  kubectl delete crds $CRDS_TO_DELETE_ON_CLEANUP
+    kubectl delete pvc -n "$OPENEBS_NAMESPACE" lvmpv-pvc
+    kubectl delete -f "${SNAP_CLASS}"
+
+    helm uninstall lvm-localpv -n "$OPENEBS_NAMESPACE" || true
+    # shellcheck disable=SC2086
+    kubectl delete crds $CRDS_TO_DELETE_ON_CLEANUP
+  fi
   # always return true
   return 0
 }
 # trap "cleanup 2>/dev/null" EXIT
-[ -n "${CLEANUP_ONLY}" ] && cleanup 2>/dev/null && exit 0
-[ -n "${RESET}" ] && cleanup 2>/dev/null
+[ -n "${CLEANUP_ONLY}" ] && cleanup && exit 0
+[ -n "${RESET}" ] && cleanup
 
 
 # setup a foreign lvm to test

--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -3,6 +3,7 @@
 set -e
 
 SNAP_CLASS="$(realpath deploy/sample/lvmsnapclass.yaml)"
+export OPENEBS_NAMESPACE=${OPENEBS_NAMESPACE:-openebs}
 
 export TEST_DIR="tests"
 
@@ -73,7 +74,7 @@ sudo sed -i '/^[^#]*thin_pool_autoextend_percent/ s/= .*/= 20/' /etc/lvm/lvm.con
 
 # Prepare env for running BDD tests
 # Minikube is already running
-helm install lvm-localpv ./deploy/helm/charts -n "$OPENEBS_NAMESPACE" --create-namespace --set lvmPlugin.pullPolicy=Never --set analytics.enabled=false
+helm install lvm-localpv ./deploy/helm/charts -n "$OPENEBS_NAMESPACE" --create-namespace --set lvmPlugin.image.pullPolicy=Never --set analytics.enabled=false
 kubectl apply -f "${SNAP_CLASS}"
 
 dumpAgentLogs() {

--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -46,7 +46,8 @@ cleanup() {
   kubectl delete -f "${SNAP_CLASS}"
 
   helm uninstall lvm-localpv -n "$OPENEBS_NAMESPACE" || true
-  kubectl delete crds "$CRDS_TO_DELETE_ON_CLEANUP"
+  # shellcheck disable=SC2086
+  kubectl delete crds $CRDS_TO_DELETE_ON_CLEANUP
   # always return true
   return 0
 }

--- a/nix/.gitignore
+++ b/nix/.gitignore
@@ -1,2 +1,3 @@
 .go/
 .tmp/
+/bins/

--- a/shell.nix
+++ b/shell.nix
@@ -21,13 +21,29 @@ pkgs.mkShell {
     cacert
     util-linux
     musl
-  ] ++ pkgs.lib.optional (builtins.getEnv "IN_NIX_SHELL" == "pure") docker;
+    jq
+    lvm2
+  ] ++ pkgs.lib.optional (builtins.getEnv "IN_NIX_SHELL" == "pure") [ docker ];
   shellHook = ''
     export GOPATH=$(pwd)/nix/.go
     export GOCACHE=$(pwd)/nix/.go/cache
     export TMPDIR=$(pwd)/nix/.tmp
     export PATH=$GOPATH/bin:$PATH
     mkdir -p "$TMPDIR"
+
+    if [ "$IN_NIX_SHELL" = "pure" ]; then
+      # working sudo within a pure nix-shell
+      for sudo in /run/wrappers/bin/sudo /usr/bin/sudo /usr/local/bin/sudo /sbin/sudo /bin/sudo; do
+        mkdir -p $(pwd)/nix/bins
+        ln -sf $sudo $(pwd)/nix/bins/sudo
+        export PATH=$(pwd)/nix/bins:$PATH
+        break
+      done
+    else
+      rm $(pwd)/nix/bins/sudo 2>/dev/null || :
+      rmdir $(pwd)/nix/bins 2>/dev/null || :
+    fi
+
     make bootstrap
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -20,6 +20,7 @@ pkgs.mkShell {
     curl
     cacert
     util-linux
+    musl
   ] ++ pkgs.lib.optional (builtins.getEnv "IN_NIX_SHELL" == "pure") docker;
   shellHook = ''
     export GOPATH=$(pwd)/nix/.go
@@ -27,5 +28,6 @@ pkgs.mkShell {
     export TMPDIR=$(pwd)/nix/.tmp
     export PATH=$GOPATH/bin:$PATH
     mkdir -p "$TMPDIR"
+    make bootstrap
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -16,14 +16,16 @@ pkgs.mkShell {
     minikube
     semver-tool
     yq-go
-  ];
+    which
+    curl
+    cacert
+    util-linux
+  ] ++ pkgs.lib.optional (builtins.getEnv "IN_NIX_SHELL" == "pure") docker;
   shellHook = ''
-    export HOME=${builtins.getEnv "HOME"}
     export GOPATH=$(pwd)/nix/.go
     export GOCACHE=$(pwd)/nix/.go/cache
     export TMPDIR=$(pwd)/nix/.tmp
     export PATH=$GOPATH/bin:$PATH
     mkdir -p "$TMPDIR"
-    make bootstrap
   '';
 }

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -282,6 +282,8 @@ func leakProtectionTest() {
 	By("Creating default storage class", createStorageClass)
 	ds := deleteNodeDaemonSet() // ensure that provisioning remains in pending state.
 
+	time.Sleep(30 * time.Second)
+
 	By("Creating PVC", createPVC)
 	time.Sleep(30 * time.Second) // wait for external provisioner to pick up new pvc
 	By("Verify pending lvm volume resource")

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -86,7 +86,7 @@ func init() {
 
 	OpenEBSNamespace = os.Getenv("OPENEBS_NAMESPACE")
 	if OpenEBSNamespace == "" {
-		klog.Fatalf("OPENEBS_NAMESPACE environment variable not set")
+		os.Setenv("OPENEBS_NAMESPACE", "openebs")
 	}
 
 	var err error


### PR DESCRIPTION
**What this PR does?**:
Ensure the namespace is always set correctly to openebs by default.
Set the image pull policy properly (wrong var was used...)

The non-buildx Dockerfile copies a binary built outside of the docker
build, which may be broken if the dependencies are not met.
This happens on nix-shell as the deps exist on /nix/store.
Get around this by building static binaries in the nix-shell.

Pin a few packages version which are not compatible on latest.
Perhaps all of them should be pinned!
Remove a few uses of sudo which should not be required?
Add a few packages missing from nix-shell
Allow make clean to work properly
Don't bootstrap by default, though this may be discussed further.
Setup goenv env variables on github actions workflows
Add gitignore for the coverage data

**Does this PR require any upgrade changes?**:

**If the changes in this PR are manually verified, list down the scenarios covered:**:

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
