### PR TITLE
build: various makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,14 +213,14 @@ manifests:
 	@echo "--------------------------------"
 	@echo "+ Generating LVM LocalPV crds"
 	@echo "--------------------------------"
-	$(PWD)/buildscripts/generate-manifests.sh
+	./buildscripts/generate-manifests.sh
 
 .PHONY: lvm-driver
 lvm-driver: format
 	@echo "--------------------------------"
 	@echo "--> Building ${CSI_DRIVER}        "
 	@echo "--------------------------------"
-	@PNAME=${CSI_DRIVER} CTLNAME=${CSI_DRIVER} sh -c "'$(PWD)/buildscripts/build.sh'"
+	@PNAME=${CSI_DRIVER} CTLNAME=${CSI_DRIVER} sh -c "'./buildscripts/build.sh'"
 
 .PHONY: lvm-driver-image
 lvm-driver-image: lvm-driver
@@ -242,7 +242,7 @@ image-ref:
 .PHONY: ci
 ci:
 	@echo "--> Running ci test";
-	$(PWD)/ci/ci-test.sh run
+	./ci/ci-test.sh run
 
 # Push lvm-driver images
 deploy-images:

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ image-ref:
 .PHONY: ci
 ci:
 	@echo "--> Running ci test";
-	$(PWD)/ci/ci-test.sh
+	$(PWD)/ci/ci-test.sh run
 
 # Push lvm-driver images
 deploy-images:

--- a/Makefile
+++ b/Makefile
@@ -235,6 +235,10 @@ lvm-driver-image: lvm-driver
 image-tag:
 	@echo ${IMAGE_TAG}
 
+.PHONY: image-repo
+image-repo:
+	@echo ${IMAGE_ORG}/${CSI_DRIVER}
+
 .PHONY: image-ref
 image-ref:
 	@echo docker.io/${IMAGE_ORG}/${CSI_DRIVER}:${IMAGE_TAG}

--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -230,26 +230,52 @@ run() {
   printf "\n\n######### All test cases passed #########\n\n"
 }
 
-load_image() {
-  make lvm-driver-image
+load_k3s() {
   if [ "${CI_K3S:-}" = "true" ]; then
-    docker save openebs/lvm-driver | ctr images import -
+    local img="${1:-}"
+    if [ -z "${1:-}" ]; then
+      repo="$(make image-repo -s -C "$SCRIPT_DIR"/.. 2>/dev/null)"
+      tag="$(make image-tag -s -C "$SCRIPT_DIR"/.. 2>/dev/null)"
+      img="$repo:$tag"
+    fi
+    docker save "$img" | ctr images import -
   fi
 }
 
+load_image() {
+  make lvm-driver-image
+  load_k3s "${1:-}"
+}
+
 maybe_load_image() {
+  local repo tag img did cid
+
   if [ "$BUILD_ALWAYS" = "true" ]; then
     load_image
     return 0
   fi
 
-  local id
-  id=$(crictl image --output json | jq --arg image "$(make image-ref -s -C "$SCRIPT_DIR"/.. 2>/dev/null)" '.images[]|select(.repoTags[0] == $image)|.id')
-  if [ -n "$id" ]; then
+  repo="$(make image-repo -s -C "$SCRIPT_DIR"/.. 2>/dev/null)"
+  tag="$(make image-tag -s -C "$SCRIPT_DIR"/.. 2>/dev/null)"
+  img="$repo:$tag"
+
+  did="$(docker image ls --no-trunc --format json | jq -r --arg repo "$repo" --arg tag "$tag" 'select(.Repository == $repo and .Tag == $tag)|.ID')"
+  if [ -z "$did" ]; then
+    make lvm-driver-image
+  fi
+
+  if ! [ "${CI_K3S:-}" = "true" ]; then
     return 0
   fi
 
-  load_image
+  cid="$(crictl image --output json | jq -r --arg image "docker.io/$(make image-ref -s -C "$SCRIPT_DIR"/.. 2>/dev/null)" '.images[]|select(.repoTags[0] == $image)|.id')"
+  # If image not present, or different to the docker source, then rebuild it!
+  if [ -z "$cid" ] || [ "$cid" != "$did" ]; then
+    load_image "$img"
+    return 0
+  fi
+
+  return 0
 }
 
 # allow override

--- a/ci/ci-test.sh
+++ b/ci/ci-test.sh
@@ -105,6 +105,7 @@ cleanup() {
       # shellcheck disable=SC2086
       kubectl delete crds $CRDS_TO_DELETE_ON_CLEANUP
       kubectl delete -f "${SNAP_CLASS}"
+      kubectl delete pod -lrole=openebs-lvm --force -n "$OPENEBS_NAMESPACE"
     fi
   fi
 
@@ -162,7 +163,8 @@ dump_logs() {
 }
 
 isPodReady(){
-  [ "$(kubectl get po "$1" -o 'jsonpath={.status.conditions[?(@.type=="Ready")].status}' -n "$OPENEBS_NAMESPACE")" = 'True' ]
+  [ "$(kubectl get po "$1" -o 'jsonpath={.status.conditions[?(@.type=="Ready")].status}' -n "$OPENEBS_NAMESPACE")" = 'True' ] &&
+  [ "$(kubectl get po "$1" -o 'jsonpath={.metadata.deletionTimestamp}' -n "$OPENEBS_NAMESPACE")" = "" ]
 }
 
 isDriverReady(){

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -277,7 +277,7 @@ You can also request one before running the tests:
 > *WARNING*: If you modify the code, remember to rebuild and load the new image, example:
 >
 > ```sh
-> ./ci/ci-test.sh run --build
+> ./ci/ci-test.sh run --build-always
 > ```
 
 If this doesn't work, you might need to dig a little deeper, or, if you're on nixos-shell, simply start over again:


### PR DESCRIPTION
    build: fix incorrect command args
    
    After adjusting the code, the docs and Makefile were not updated.

---

    build: remove incorrect use of pwd
    
    Makefile commands can be run from another path, example:
    make -C $lvm clean
    
    In this case the pwd is not the correct path prefix!

---
    test: more robust check for lvm driver ready
    
    Ensure there's no deleting pod present
    Also force delete the old pods on uninstall

---

    test(ci): optimize image build and load

