### PR TITLE
fix(resize): validate lv size before executing lvextend

### DIFF
--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -375,6 +375,55 @@ func GetVolumeDevPath(vol *apis.LVMVolume) (string, error) {
 	return dev, nil
 }
 
+// Validate the size volume based on extents. If the number of extents are already
+// greater than or equal to required, then make a no-op.
+func needsLvResize(vol *apis.LVMVolume, desiredSizeBytes uint64) bool {
+	lvPath := DevPath + vol.Spec.VolGroup + "/" + vol.Name
+	vgName := vol.Spec.VolGroup
+
+	// 1. Get LV Size in bytes, without the unit suffix.
+	lvSizeBytes, _, err := RunCommandSplit(LVList, "-o", "lv_size", "--noheadings", "--nosuffix", "--units", "b", lvPath)
+	if err != nil {
+		klog.Warningf("failed to get LV size for %s: %w", lvPath, err)
+		return true
+	}
+
+	lvSizeBytesStr := strings.TrimSpace(string(lvSizeBytes))
+	lvSize, err := strconv.ParseUint(lvSizeBytesStr, 10, 64) // Parse as int64
+	if err != nil {
+		klog.Warningf("failed to parse LV size %v for %s: %w", lvSizeBytesStr, lvPath, err)
+		return true
+	}
+
+	// 2. Get VG Extent Size in bytes
+	// Similar to LV size, get VG extent size in bytes without suffix.
+	vgExtentSizeBytes, _, err := RunCommandSplit(VGList, "-o", "vg_extent_size", "--noheadings", "--nosuffix", "--units", "b", vgName)
+	if err != nil {
+		klog.Warningf("failed to get VG extent size for %s: %w", vgName, err)
+		return true
+	}
+
+	vgExtentSizeStr := strings.TrimSpace(string(vgExtentSizeBytes))
+	vgExtentSize, err := strconv.ParseUint(vgExtentSizeStr, 10, 64) // Parse as int64
+	if err != nil {
+		klog.Warningf("failed to parse VG extent size '%s' to integer: %w", vgExtentSizeStr, err)
+		return true
+	}
+
+	// 3. Calculate current Logical Extents
+	// Ensure VG extent size is not zero to prevent division by zero.
+	if vgExtentSize == 0 {
+		klog.Warningf("VG extent size is zero, cannot calculate logical extents")
+		return true
+	}
+
+	currNumLEs := uint64(lvSize / vgExtentSize)
+	requiredNumLEs := uint64(desiredSizeBytes / vgExtentSize)
+	klog.Infof("num logical extents - current: %v, required:  %v", currNumLEs, requiredNumLEs)
+
+	return currNumLEs < requiredNumLEs
+}
+
 // builldVolumeResizeArgs returns resize command for the lvm volume
 func buildVolumeResizeArgs(vol *apis.LVMVolume, resizefs bool) []string {
 	var LVMVolArg []string
@@ -404,8 +453,8 @@ func ResizeLVMVolume(vol *apis.LVMVolume, resizefs bool) error {
 	// before exapnding LVM volume(If volume is already expanded then
 	// it might be error prone). This also makes ResizeLVMVolume func
 	// idempotent
+	desiredVolSize, err := strconv.ParseUint(vol.Spec.Capacity, 10, 64)
 	if !resizefs {
-		desiredVolSize, err := strconv.ParseUint(vol.Spec.Capacity, 10, 64)
 		if err != nil {
 			return err
 		}
@@ -423,6 +472,11 @@ func ResizeLVMVolume(vol *apis.LVMVolume, resizefs bool) error {
 	}
 
 	volume := vol.Spec.VolGroup + "/" + vol.Name
+
+	resize_needed := needsLvResize(vol, desiredVolSize)
+	if !resize_needed {
+		return nil
+	}
 
 	args := buildVolumeResizeArgs(vol, resizefs)
 	out, _, err := RunCommandSplit(LVExtend, args...)


### PR DESCRIPTION
Fetch the lv size in extents and validate if we really need to run the lvextend.

**Why is this PR required? What issue does it fix?**:
Fixes #381

**What this PR does?**:
Fetch the lv size in extents and validate if we really need to run the lvextend.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
Do lvextend of LV on the host. Then edit the PVC to request the same size as already done via lvextend.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #381
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

