### PR TITLE
feat(helm chart): add optional ServiceMonitor for lvmNode service

### DIFF
--- a/deploy/helm/charts/templates/lvm-node-servicemonitor.yaml
+++ b/deploy/helm/charts/templates/lvm-node-servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) .Values.lvmNode.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "lvmlocalpv.fullname" . }}-node-servicemonitor
+  namespace: {{- .Release.Namespace }}
+  labels:
+    #release: prometheus  # Adjust to match your Prometheus Operator's release name
+    {{- .Values.lvmNode.serviceMonitor.labels | toYaml | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+    {{- include "lvmlocalpv.lvmNode.labels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{- .Release.Namespace }}
+  endpoints:
+    - port: metrics
+      path: /metrics
+      interval: 30s
+      scrapeTimeout: 10s
+{{- end }}
+

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -64,7 +64,11 @@ lvmNode:
     burst: 0
   # Disable or enable the use of hostNetwork for the lvm node daemonset.
   hostNetwork: false
-
+  serviceMonitor:
+    enabled: false
+    # add labels to the serviceMonitor if you make use of serviceMonitorSelector in prometheus operator
+#   labels:
+#     release: prometheus
 
 # lvmController contains the configurables for
 # the lvm controller deployment


### PR DESCRIPTION
Option to deploy a servicemonitor (prometheus operator) to automatically scrape the lvmNode metrics.

## Pull Request template

Please, go through these steps before you submit a PR.

**Why is this PR required? What issue does it fix?**:

It allows for creating a Prometheus Operator ServiceMonitor to scrape the lvmNode metrics.
Right now one has to create one outside manually. 

**What this PR does?**:
It allows for creating a Prometheus Operator ServiceMonitor to scrape the lvmNode metrics.

By setting `lvmNode.serviceMonitor.enabled` to `true`  and specifying whatever label ones PrometheusOperator  looks for (common is to have release: promtetheus) 

**Does this PR require any upgrade changes?**:
No (at least I don't think so)

**If the changes in this PR are manually verified, list down the scenarios covered:**:

`helm template .  | grep ServiceMonitor` 
will not render anything by default

Setting lvmNode.serviceMonitor.enabled=true" will render the template.
`helm template . --set lvmNode.serviceMonitor.enabled=true | grep ServiceMonitor`

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: