### PR TITLE
feat: reclaim thinpool capacity after last thin lv deletion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/container-storage-interface/spec v1.9.0
+	github.com/creack/pty v1.1.21
 	github.com/kubernetes-csi/csi-lib-utils v0.9.0
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.27.4
@@ -22,6 +23,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible
 	k8s.io/code-generator v0.27.2
 	k8s.io/klog/v2 v2.100.1
+	k8s.io/mount-utils v0.26.15
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
 	sigs.k8s.io/controller-runtime v0.2.0
 	sigs.k8s.io/yaml v1.3.0
@@ -78,7 +80,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.27.2 // indirect
 	k8s.io/gengo v0.0.0-20230306165830-ab3349d207d4 // indirect
 	k8s.io/kube-openapi v0.0.0-20230525220651-2546d827e515 // indirect
-	k8s.io/mount-utils v0.26.15 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/testing_frameworks v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,8 @@ github.com/container-storage-interface/spec v1.9.0 h1:zKtX4STsq31Knz3gciCYCi1SXt
 github.com/container-storage-interface/spec v1.9.0/go.mod h1:ZfDu+3ZRyeVqxZM0Ds19MVLkN2d1XJ5MAfi1L3VjlT0=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.21 h1:1/QdRyBaHHJP61QkWMXlOIBfsgdDeeKfK8SYVUWJKf0=
+github.com/creack/pty v1.1.21/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -107,7 +109,6 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -227,7 +228,6 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.5/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -236,7 +236,6 @@ github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHm
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -278,7 +277,6 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -17,15 +17,19 @@ limitations under the License.
 package lvm
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/creack/pty"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
@@ -312,11 +316,14 @@ func CreateVolume(vol *apis.LVMVolume) error {
 
 // DestroyVolume deletes the lvm volume
 func DestroyVolume(vol *apis.LVMVolume) error {
+	is_thin := strings.TrimSpace(vol.Spec.ThinProvision) == YES
+
 	if vol.Spec.VolGroup == "" {
 		klog.Infof("volGroup not set for lvm volume %v, skipping its deletion", vol.Name)
 		return nil
 	}
 
+	vgname := vol.Spec.VolGroup
 	volume := vol.Spec.VolGroup + "/" + vol.Name
 
 	volExists, err := CheckVolumeExists(vol)
@@ -345,7 +352,205 @@ func DestroyVolume(vol *apis.LVMVolume) error {
 
 	klog.Infof("lvm: destroyed volume %s", volume)
 
+	// If the destroyed volume was a thinvol, then check if it was the
+	// last one on the corresponding thinpool. If yes, then destroy the
+	// thinpool too.
+	if is_thin {
+		thinpool_lv := vgname + "_thinpool"
+		can_destroy := checkThinPoolEmpty(thinpool_lv)
+		name := vgname + "/" + thinpool_lv
+		klog.Infof("Destroy: %v. thinpool: %s", can_destroy, name)
+		// Addressing TOCTOU vulnerability. A new thin lv might get created after we checked above,
+		// and before we issue remove. The new lv will get destroyed in such case. Hence,
+		// parsing prompts to decide and act accordingly. Don't return an error though, if we fail
+		// to remove thinpool for any reason.
+		if can_destroy {
+			cmd := exec.Command(LVRemove, name)
+			// Start the command with a PTY
+			ptmx, err := pty.Start(cmd)
+			if err != nil {
+				klog.Infof("failed to start lvremove in PTY: %v", err)
+				return nil
+			}
+			defer func() {
+				ptmx.Close()
+				klog.Infof("PTY closed for thinpool removal of %s", name)
+			}()
+
+			// Create a channel to signal when the command is done
+			done := make(chan error, 1)
+			go func() {
+				done <- cmd.Wait()
+				close(done)
+			}()
+
+			// Create a reader with a buffer
+			reader := bufio.NewReader(ptmx)
+
+			// Set up a timeout for the entire operation
+			timeout := time.After(30 * time.Second)
+
+			// Buffer to store partial lines
+			var partialLine strings.Builder
+
+			// Read buffer
+			buf := make([]byte, 1024)
+
+			// Read and respond to prompts until the command completes
+			for {
+				select {
+				case err, ok := <-done:
+					// Command completed or channel closed
+					if !ok || err == nil {
+						klog.Infof("Successfully removed thinpool %s", name)
+					} else {
+						klog.Errorf("lvremove failed for thinpool %s: %v", name, err)
+					}
+					return nil
+
+				case <-timeout:
+					klog.Warningf("Thinpool removal timed out after 30 seconds for %s", name)
+					if cmd.Process != nil {
+						if err := cmd.Process.Kill(); err != nil {
+							klog.Errorf("Failed to kill process: %v", err)
+						}
+					}
+					klog.Errorf("thinpool removal timed out")
+					return nil
+
+				default:
+					// Set a read deadline to avoid blocking forever
+					err := ptmx.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+					if err != nil {
+						klog.Warningf("Failed to set read deadline: %v", err)
+					}
+
+					// Try to read from the PTY
+					n, err := reader.Read(buf)
+
+					if err != nil {
+						// Store original error for later use
+						origErr := err
+
+						// Check if it's a timeout error
+						if timeoutErr, ok := err.(interface{ Timeout() bool }); ok && timeoutErr.Timeout() {
+							// This is just a timeout, continue waiting
+							continue
+						} else if origErr == io.EOF {
+							// End of output, check if command is done
+							select {
+							case err, ok := <-done:
+								if !ok || err == nil {
+									klog.Infof("Successfully removed thinpool %s after EOF", name)
+									return nil
+								}
+								return fmt.Errorf("lvremove failed after EOF: %v", err)
+							default:
+								// Command still running, continue
+								continue
+							}
+						} else {
+							klog.Warningf("Error reading from PTY: %v", err)
+							// Check if command is done despite read error
+							select {
+							case err, ok := <-done:
+								if !ok || err == nil {
+									return nil
+								}
+								return fmt.Errorf("lvremove failed: %v", err)
+							default:
+								// Command still running, continue
+								continue
+							}
+						}
+					}
+
+					if n > 0 {
+						output := string(buf[:n])
+						partialLine.WriteString(output)
+						klog.Infof("lvremove raw output: %s", output)
+
+						// Keep buffer to a reasonable size (avoid unbounded growth)
+						if partialLine.Len() > 4096 {
+							partialLine.Reset()
+							partialLine.WriteString(output)
+						}
+
+						content := partialLine.String()
+
+						// Check for prompts directly in the raw output
+						if strings.Contains(content, "Do you really want to remove") {
+							klog.Info("Empty thinpool prompt detected in raw output, responding with 'y'")
+
+							n, err := ptmx.Write([]byte("y\n"))
+							if err != nil {
+								klog.Errorf("Failed to write 'y': %v", err)
+							} else {
+								klog.Infof("Successfully wrote %d bytes ('y\\n') to the command", n)
+							}
+							continue
+						} else if strings.Contains(content, "will remove") && strings.Contains(content, "dependent volume") {
+							klog.Info("Non-empty thinpool prompt detected in raw output, responding with 'n'")
+
+							n, err := ptmx.Write([]byte("n\n"))
+							if err != nil {
+								klog.Errorf("Failed to write 'n': %v", err)
+							} else {
+								klog.Infof("Successfully wrote %d bytes ('n\\n') to the command", n)
+							}
+
+							// Since we're not removing a non-empty thinpool, we can exit
+							return nil
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return nil
+}
+
+// If there is no thin LV on the thinpool, return true.
+func checkThinPoolEmpty(poolname string) bool {
+	data := &struct {
+		Report []struct {
+			LV []struct {
+				LVName string `json:"lv_name"`
+				PoolLV string `json:"pool_lv"`
+			} `json:"lv"`
+		} `json:"report"`
+	}{}
+
+	args := []string{
+		"--reportformat", "json",
+		"-o", "lv_name,pool_lv",
+	}
+
+	out, err_out, err := RunCommandSplit(LVList, args...)
+
+	if err != nil {
+		klog.Errorf("failed to run lvs list: %v, output: %s", err, string(err_out))
+		return false
+	}
+
+	if err := json.Unmarshal(out, &data); err != nil {
+		klog.Errorf("failed to parse JSON: %v", err)
+		return false
+	}
+
+	for _, report := range data.Report {
+		for _, lv := range report.LV {
+			if lv.PoolLV == poolname {
+				klog.Warningf("found at least one thin LV on thinpool %v", lv.PoolLV)
+				// Found at least one thin LV
+				return false
+			}
+		}
+	}
+
+	// No thin LV found on the pool
+	return true
 }
 
 // CheckVolumeExists validates if lvm volume exists

--- a/tests/lvm_utils.go
+++ b/tests/lvm_utils.go
@@ -246,3 +246,24 @@ func VerifyThinpoolExtend() {
 		45*time.Second, 5*time.Second).
 		Should(gomega.BeTrue())
 }
+
+// Verify if thinpool is deleted or not as per input expectation.
+func VerifyThinPoolDeletion(vg string, thinpool string, expect_deleted bool) {
+	thinpool_lv := vg + "/" + thinpool
+
+	args := []string{
+		"lvs",
+		"--noheadings",
+		thinpool_lv,
+	}
+
+	stdout, _, err := execAtLocal("sudo", nil, args...)
+	fmt.Printf("VerifyThinPoolDeletion: expect_deleted: %v, err: %v, output: \n%s\n", expect_deleted, err, stdout)
+	// When expect_deleted is true it means we are expecting `lvs` command to list the thinpool, which
+	// means err will be nil. Otherwise, err is non-nil (error code 5) when thinpool is not found.
+	if expect_deleted {
+		gomega.Expect(err).Should(gomega.HaveOccurred(), "shouldn't find the thinpool")
+	} else {
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), "should've found the thinpool")
+	}
+}

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -28,6 +28,7 @@ var _ = Describe("[lvmpv] TEST VOLUME PROVISIONING", func() {
 		It("Running volume Creation Tests", volumeCreationTest)
 		It("Running scheduling Tests", schedulingTest)
 		It("Running volume/snapshot Capacity Tests", capacityTest)
+		It("Running volume Deletion Tests", volumeDeletionTest)
 	})
 })
 
@@ -342,6 +343,24 @@ func volumeCreationTest() {
 	By("###Running thin volume creation test###", thinVolCreationTest)
 	By("###Running leak protection test###", leakProtectionTest)
 	By("###Running shared volume for two app pods on same node test###", sharedVolumeTest)
+}
+
+func volumeDeletionTest() {
+	device := setupVg(40, "lvmvg")
+	defer cleanupVg(device, "lvmvg")
+	By("Creating thinProvision storage class", createThinStorageClass)
+	By("Creating and verifying a PVC bound status")
+	createAndVerifyBlockPVCId(true, "1")
+	By("Verifying LVMVolume object to be Ready")
+	VerifyLVMVolume(true, "")
+	By("Creating and verifying another PVC bound status")
+	createAndVerifyBlockPVCId(true, "2")
+	By("Verifying LVMVolume object to be Ready")
+	VerifyLVMVolume(true, "")
+	deleteAndVerifyPVC(pvcName + "-1")
+	VerifyThinPoolDeletion("lvmvg", "lvmvg_thinpool", false)
+	deleteAndVerifyPVC(pvcName + "-2")
+	VerifyThinPoolDeletion("lvmvg", "lvmvg_thinpool", true)
 }
 
 func schedulingTest() {

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -350,12 +350,42 @@ func verifyPVCStatus(pvc_name string, expect_bound bool) {
 		"while checking the pvc status")
 }
 
-func createAndVerifyBlockPVC(expect_bound bool) {
-	var (
-		err     error
-		pvcName = "lvmpv-pvc"
-	)
+func createAndVerifyBlockPVCId(expect_bound bool, id_suffix string) {
+	var pvcName = "lvmpv-pvc" + "-" + id_suffix
 
+	createBlockPVC(pvcName)
+	verifyBlockPVCName(expect_bound, pvcName)
+}
+func createAndVerifyBlockPVC(expect_bound bool) {
+	var pvcName = "lvmpv-pvc"
+
+	createBlockPVC(pvcName)
+	verifyBlockPVCName(expect_bound, pvcName)
+}
+
+func verifyBlockPVCName(expect_bound bool, pvcName string) {
+	var err error
+	ginkgo.By("verifying pvc status as bound\n")
+
+	ok := false
+	if !expect_bound {
+		ok = IsPVCPendingConsistently(pvcName)
+	} else {
+		ok = IsPVCBoundEventually(pvcName)
+	}
+	gomega.Expect(ok).To(gomega.Equal(true),
+		"while checking the pvc status")
+
+	pvcObj, err = PVCClient.WithNamespace(OpenEBSNamespace).Get(pvcObj.Name, metav1.GetOptions{})
+	gomega.Expect(err).To(
+		gomega.BeNil(),
+		"while retrieving pvc {%s} in namespace {%s}",
+		pvcName,
+		OpenEBSNamespace,
+	)
+}
+func createBlockPVC(pvcName string) {
+	var err error
 	volmode := corev1.PersistentVolumeBlock
 
 	ginkgo.By("building a pvc")
@@ -378,25 +408,6 @@ func createAndVerifyBlockPVC(expect_bound bool) {
 	gomega.Expect(err).To(
 		gomega.BeNil(),
 		"while creating pvc {%s} in namespace {%s}",
-		pvcName,
-		OpenEBSNamespace,
-	)
-
-	ginkgo.By("verifying pvc status as bound\n")
-
-	ok := false
-	if !expect_bound {
-		ok = IsPVCPendingConsistently(pvcName)
-	} else {
-		ok = IsPVCBoundEventually(pvcName)
-	}
-	gomega.Expect(ok).To(gomega.Equal(true),
-		"while checking the pvc status")
-
-	pvcObj, err = PVCClient.WithNamespace(OpenEBSNamespace).Get(pvcObj.Name, metav1.GetOptions{})
-	gomega.Expect(err).To(
-		gomega.BeNil(),
-		"while retrieving pvc {%s} in namespace {%s}",
 		pvcName,
 		OpenEBSNamespace,
 	)


### PR DESCRIPTION

**Why is this PR required? What issue does it fix?**: Reclaims capacity claimed but unused by the thin pool.

**What this PR does?**: Adds an additional step to delete the thin pool if the last thin lv hosted by it has been deleted.

**Does this PR require any upgrade changes?**: No

**If the changes in this PR are manually verified, list down the scenarios covered:**: Added a CI test for scenario where thinpool deletion is expected and not-expected.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_


**Checklist:**
- [x] Fixes #121 
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [x] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

