### PR TITLE
make delete volume idempotent when node is removed from cluster

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -19,6 +19,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -471,6 +472,28 @@ func (cs *controller) DeleteVolume(
 	return csipayload.NewDeleteVolumeResponseBuilder().Build(), nil
 }
 
+// Checks if k8s node is present. If the check fails with any other reason then NotFound.
+// We will return true and assume node is present.
+func isNodePresent(nodeId string) bool {
+	cfg, err := k8sapi.Config().Get()
+	if err != nil {
+		return true
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return true
+	}
+
+	_, err = kubeClient.CoreV1().Nodes().Get(context.TODO(), nodeId, metav1.GetOptions{})
+	if err != nil {
+		if k8serror.IsNotFound(err) {
+			return false
+		}
+	}
+	return true
+}
+
 func (cs *controller) deleteVolume(ctx context.Context, volumeID string) error {
 	klog.Infof("received request to delete volume %q", volumeID)
 	vol, err := lvm.GetLVMVolume(volumeID)
@@ -481,7 +504,6 @@ func (cs *controller) deleteVolume(ctx context.Context, volumeID string) error {
 		return errors.Wrapf(err,
 			"failed to get volume for {%s}", volumeID)
 	}
-
 	// if volume is not already triggered for deletion, delete the volume.
 	// otherwise, just wait for the existing deletion operation to complete.
 	if vol.GetDeletionTimestamp() == nil {
@@ -489,6 +511,17 @@ func (cs *controller) deleteVolume(ctx context.Context, volumeID string) error {
 			return errors.Wrapf(err,
 				"failed to handle delete volume request for {%s}", volumeID)
 		}
+	}
+	present := isNodePresent(vol.Spec.OwnerNodeID)
+	if !present {
+		klog.Warningf("Removing finalizer as node %s is not present in cluster", vol.Spec.OwnerNodeID)
+		if err = lvm.RemoveVolFinalizer(vol); err != nil {
+			return err
+		}
+		if err = lvm.VerifyLVMVolumeDestroy(volumeID); err != nil {
+			return err
+		}
+		return nil
 	}
 	if err = lvm.WaitForLVMVolumeDestroy(ctx, volumeID); err != nil {
 		return err

--- a/pkg/lvm/volume.go
+++ b/pkg/lvm/volume.go
@@ -104,7 +104,7 @@ func ProvisionVolume(vol *apis.LVMVolume) (*apis.LVMVolume, error) {
 func DeleteVolume(volumeID string) (err error) {
 	err = volbuilder.NewKubeclient().WithNamespace(LvmNamespace).Delete(volumeID)
 	if err == nil {
-		klog.Infof("deprovisioned volume %s", volumeID)
+		klog.Infof("deprovisioning volume %s", volumeID)
 	}
 
 	return
@@ -162,6 +162,23 @@ func WaitForLVMVolumeDestroy(ctx context.Context, volumeID string) error {
 		}
 		timer.Reset(1 * time.Second)
 	}
+}
+
+// Verifies if lvmvolume CR got removed after removing finaliser.
+func VerifyLVMVolumeDestroy(volumeID string) error {
+	for i := 0; i < 10; i++ {
+		_, err := GetLVMVolume(volumeID)
+		if err != nil {
+			if k8serror.IsNotFound(err) {
+				return nil
+			}
+			return status.Errorf(codes.Internal,
+				"lvmvolume: destroy wait failed, not able to get the volume %s %s", volumeID, err.Error())
+		}
+		time.Sleep(time.Duration(100 * time.Millisecond))
+	}
+	return status.Errorf(codes.DeadlineExceeded,
+		"lvmvolume: %s not removed after removing finaliser", volumeID)
 }
 
 // GetLVMVolumeState returns LVMVolume OwnerNode and State for


### PR DESCRIPTION
When a Kubernetes node is removed from the cluster while it still has existing PVCs/LVMVolumes, those volumes become orphaned. If a PVC is deleted in this state, the LocalPV-LVM CSI controller marks the corresponding LVMVolume CR for deletion by adding a deletion timestamp.

Normally, the node-agent running on the worker node is responsible for cleaning up the logical volume (LV) and removing the finalizer from the CR. However, in this scenario, the node no longer exists, so there is no agent running to perform the cleanup.

This fix leverages the condition of the Kubernetes Node being absent: in such cases, the CSI controller itself removes the finalizer and cleans up the LVMVolume CR.

Fixes: https://github.com/openebs/lvm-localpv/issues/407