### PR TITLE
chore: update base alpine image from 3.18.4 to 3.22.1

### DIFF
--- a/buildscripts/lvm-driver/Dockerfile
+++ b/buildscripts/lvm-driver/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18.4
+FROM alpine:3.22.1
 RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
 RUN apk add --no-cache btrfs-progs xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates libc6-compat

--- a/buildscripts/lvm-driver/Dockerfile.buildx
+++ b/buildscripts/lvm-driver/Dockerfile.buildx
@@ -41,7 +41,7 @@ COPY . .
 
 RUN make buildx.csi-driver
 
-FROM alpine:3.18.4
+FROM alpine:3.22.1
 RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
 RUN apk add --no-cache btrfs-progs xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates


### PR DESCRIPTION
Description

This PR updates the base image from Alpine 3.18.4 to Alpine 3.22.1.

Reason

The previous version (3.18.4) contained known security vulnerabilities.

Upgrading to 3.22.1 ensures improved security.

Impact

No functional changes to the application logic.

Reduced exposure to security risks.