### PR TITLE
feat(restore): add controller changes to enable restore from thin snapshot

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"github.com/openebs/lvm-localpv/pkg/driver"
 	"github.com/openebs/lvm-localpv/pkg/driver/config"

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -114,6 +114,13 @@ spec:
                 - "yes"
                 - "no"
                 type: string
+              source:
+                description: |-
+                  Source defines the data source from which the volume should be created.
+                  It can reference either a snapshot or an existing volume.
+                  If not specified, a standard LVM volume will be created.
+                  If specified, the new volume will be created using the defined data source.
+                type: string
               thinProvision:
                 description: |-
                   ThinProvision specifies whether logical volumes can be thinly provisioned.
@@ -236,6 +243,10 @@ spec:
               snapSize:
                 description: SnapSize specifies the space reserved for the snapshot
                 type: string
+              thinProvision:
+                description: ThinProvision specifies whether the snapshot is thin-provisioned
+                  or not.
+                type: boolean
               volGroup:
                 description: VolGroup specifies the name of the volume group where
                   the snapshot has been created.
@@ -248,6 +259,14 @@ spec:
             description: SnapStatus string that reflects if the snapshot was created
               successfully
             properties:
+              lvSize:
+                anyOf:
+                - type: integer
+                - type: string
+                description: LvSize specifies the size allocated for the snapshot
+                  in the VG
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               state:
                 type: string
             type: object

--- a/deploy/yamls/lvmsnapshot-crd.yaml
+++ b/deploy/yamls/lvmsnapshot-crd.yaml
@@ -60,6 +60,10 @@ spec:
               snapSize:
                 description: SnapSize specifies the space reserved for the snapshot
                 type: string
+              thinProvision:
+                description: ThinProvision specifies whether the snapshot is thin-provisioned
+                  or not.
+                type: boolean
               volGroup:
                 description: VolGroup specifies the name of the volume group where
                   the snapshot has been created.
@@ -72,6 +76,14 @@ spec:
             description: SnapStatus string that reflects if the snapshot was created
               successfully
             properties:
+              lvSize:
+                anyOf:
+                - type: integer
+                - type: string
+                description: LvSize specifies the size allocated for the snapshot
+                  in the VG
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               state:
                 type: string
             type: object

--- a/deploy/yamls/lvmvolume-crd.yaml
+++ b/deploy/yamls/lvmvolume-crd.yaml
@@ -93,6 +93,13 @@ spec:
                 - "yes"
                 - "no"
                 type: string
+              source:
+                description: |-
+                  Source defines the data source from which the volume should be created.
+                  It can reference either a snapshot or an existing volume.
+                  If not specified, a standard LVM volume will be created.
+                  If specified, the new volume will be created using the defined data source.
+                type: string
               thinProvision:
                 description: |-
                   ThinProvision specifies whether logical volumes can be thinly provisioned.

--- a/pkg/apis/openebs.io/lvm/v1alpha1/lvmsnapshot.go
+++ b/pkg/apis/openebs.io/lvm/v1alpha1/lvmsnapshot.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -47,6 +48,9 @@ type LVMSnapshotSpec struct {
 
 	// SnapSize specifies the space reserved for the snapshot
 	SnapSize string `json:"snapSize,omitempty"`
+
+	// ThinProvision specifies whether the snapshot is thin-provisioned or not.
+	ThinProvision bool `json:"thinProvision,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -63,4 +67,7 @@ type LVMSnapshotList struct {
 // SnapStatus string that reflects if the snapshot was created successfully
 type SnapStatus struct {
 	State string `json:"state,omitempty"`
+
+	// LvSize specifies the size allocated for the snapshot in the VG
+	LvSize resource.Quantity `json:"lvSize,omitempty"`
 }

--- a/pkg/apis/openebs.io/lvm/v1alpha1/lvmvolume.go
+++ b/pkg/apis/openebs.io/lvm/v1alpha1/lvmvolume.go
@@ -85,6 +85,12 @@ type VolumeInfo struct {
 	// thinProvision i.e. logical volumes that are larger than the available extents.
 	// +kubebuilder:validation:Enum=yes;no
 	ThinProvision string `json:"thinProvision,omitempty"`
+
+	// Source defines the data source from which the volume should be created.
+	// It can reference either a snapshot or an existing volume.
+	// If not specified, a standard LVM volume will be created.
+	// If specified, the new volume will be created using the defined data source.
+	Source string `json:"source,omitempty"`
 }
 
 // VolStatus string that specifies the current state of the volume provisioning request.

--- a/pkg/builder/snapbuilder/build.go
+++ b/pkg/builder/snapbuilder/build.go
@@ -19,6 +19,7 @@ package snapbuilder
 import (
 	"github.com/openebs/lib-csi/pkg/common/errors"
 	apis "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // Builder is the builder object for LVMSnapshot
@@ -141,6 +142,18 @@ func (b *Builder) WithVolGroup(vg string) *Builder {
 		return b
 	}
 	b.snap.Object.Spec.VolGroup = vg
+	return b
+}
+
+// WithLvSize sets the snapshot LV size at the time the snapshot was created
+func (b *Builder) WithLvSize(size resource.Quantity) *Builder {
+	b.snap.Object.Status.LvSize = size
+	return b
+}
+
+// WithThinProvision sets whether the snapshot is thin-provisioned or not
+func (b *Builder) WithThinProvision(thin bool) *Builder {
+	b.snap.Object.Spec.ThinProvision = thin
 	return b
 }
 

--- a/pkg/builder/volbuilder/volume.go
+++ b/pkg/builder/volbuilder/volume.go
@@ -207,6 +207,12 @@ func (b *Builder) WithFinalizer(finalizer []string) *Builder {
 	return b
 }
 
+// WithSource sets the source from which the volume should be created
+func (b *Builder) WithSource(source string) *Builder {
+	b.volume.Object.Spec.Source = source
+	return b
+}
+
 // Build returns LVMVolume API object
 func (b *Builder) Build() (*apis.LVMVolume, error) {
 	if len(b.errs) > 0 {

--- a/pkg/driver/agent.go
+++ b/pkg/driver/agent.go
@@ -38,7 +38,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	apis "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
 	"github.com/openebs/lvm-localpv/pkg/builder/volbuilder"

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -22,7 +22,7 @@ import (
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	lvmapi "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
@@ -243,6 +243,42 @@ func (cs *controller) init() error {
 	return nil
 }
 
+func validateRestoreRequestFromSnapshot(lvmSnapCr *lvmapi.LVMSnapshot,
+	req *csi.CreateVolumeRequest,
+	params *VolumeParams,
+) error {
+	// verify that the snapshot is of thin type
+	// only thin snapshot can be used to restore a volume
+	// also verify that the new volume to be created from snapshot
+	// is also thin provisioned
+	if !lvmSnapCr.Spec.ThinProvision {
+		return status.Errorf(codes.InvalidArgument, "snapshot %s is not of thin type", lvmSnapCr.Name)
+	} else if params.ThinProvision != lvm.YES {
+		return status.Errorf(codes.InvalidArgument, "only thin restores supported today.")
+	}
+
+	vgPattern := fmt.Sprintf("^%v$", lvmSnapCr.Spec.VolGroup)
+
+	// verify that the volume group of the new volume to be created
+	// from snapshot is same as that of the snapshot
+	if params.VgPattern.String() != vgPattern {
+		return status.Errorf(codes.InvalidArgument, "volume group of the restore volume can't be different from that of source (snapshot %s)",
+			lvmSnapCr.Name)
+	}
+
+	reqCapacity := getRoundedCapacity(
+		req.GetCapacityRange().RequiredBytes)
+
+	// verify that the capacity of the restore volume to be created
+	// from snapshot should equal to the snapshot LV size
+	if lvmSnapCr.Status.LvSize.Value() != reqCapacity {
+		return status.Errorf(codes.OutOfRange, "capacity of the restore volume %v to be created from snapshot must be equal to snapshot LV size %d",
+			reqCapacity,
+			lvmSnapCr.Status.LvSize.Value())
+	}
+	return nil
+}
+
 // CreateLVMVolume create new lvm volume for csi volume request
 func CreateLVMVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 	params *VolumeParams) (*lvmapi.LVMVolume, error) {
@@ -278,22 +314,50 @@ func CreateLVMVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 			}
 		}
 	}
+	var owner string             // owner node where volume is to be created
+	var lvmSnapshotCrName string // snapshot name if volume is to be created from snapshot
+	var volGroup string          // volume group where volume is to be created
+	// if volume is to be created from snapshot, verify request with snapshot values
+	if req.GetVolumeContentSource() != nil && req.GetVolumeContentSource().GetSnapshot() != nil {
+		snapId := req.GetVolumeContentSource().GetSnapshot().GetSnapshotId()
+		// snapshot ID is of the form <volume-name>@<snapshot-name>
+		parts := strings.Split(snapId, "@")
+		if len(parts) != 2 {
+			return nil, status.Errorf(codes.Internal,
+				"invalid snapshot ID %s", snapId)
+		}
+		lvmSnapCr, err := lvm.GetLVMSnapshot(parts[1])
+		if err != nil {
+			return nil, status.Errorf(codes.NotFound, "snapshot %s not found: %s", parts[1], err.Error())
+		}
+		// verify snapshot values like thinSnapshot,owner node, thinprovision and volume group and capacity for the new volume
+		if err = validateRestoreRequestFromSnapshot(lvmSnapCr, req, params); err != nil {
+			return nil, err
+		}
 
-	nmap, err := getNodeMap(params.Scheduler, params.VgPattern)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "get node map failed : %s", err.Error())
+		owner = lvmSnapCr.Spec.OwnerNodeID
+		lvmSnapshotCrName = lvmSnapCr.Name
+		volGroup = lvmSnapCr.Spec.VolGroup
 	}
 
-	// run the scheduler
-	selected := schd.Scheduler(req, nmap)
+	// if owner is not already set from snapshot, run the scheduler
+	// to select the owner node for the volume
+	if owner == "" {
+		nmap, err := getNodeMap(params.Scheduler, params.VgPattern)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "get node map failed : %s", err.Error())
+		}
 
-	if len(selected) == 0 {
-		return nil, status.Error(codes.Internal, "scheduler failed, not able to select a node to create the PV")
+		// run the scheduler
+		selected := schd.Scheduler(req, nmap)
+		if len(selected) == 0 {
+			return nil, status.Error(codes.Internal, "scheduler failed, not able to select a node to create the PV")
+		}
+
+		owner = selected[0]
+		klog.Infof("scheduling the volume %s/%s on node %s",
+			params.VgPattern.String(), volName, owner)
 	}
-
-	owner := selected[0]
-	klog.Infof("scheduling the volume %s/%s on node %s",
-		params.VgPattern.String(), volName, owner)
 
 	volObj, err := volbuilder.NewBuilder().
 		WithName(volName).
@@ -305,7 +369,20 @@ func CreateLVMVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 		WithThinProvision(params.ThinProvision).Build()
 
 	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, status.Errorf(codes.Internal,
+			"failed to build lvm volume object for %s: {%s}",
+			volName, err.Error())
+	}
+
+	if lvmSnapshotCrName != "" {
+		volObj, err = volbuilder.BuildFrom(volObj).
+			WithSource(lvmSnapshotCrName).
+			WithVolGroup(volGroup).Build()
+		if err != nil {
+			return nil, status.Errorf(codes.Internal,
+				"failed to update lvm volume object with source and volgroup for %s: {%s}",
+				volName, err.Error())
+		}
 	}
 
 	vol, err = lvm.ProvisionVolume(volObj)
@@ -336,26 +413,20 @@ func (cs *controller) CreateVolume(
 	size := getRoundedCapacity(req.GetCapacityRange().GetRequiredBytes())
 	contentSource := req.GetVolumeContentSource()
 
-	var vol *lvmapi.LVMVolume
-	if contentSource != nil && contentSource.GetSnapshot() != nil {
+	if contentSource != nil && contentSource.GetVolume() != nil {
 		return nil, status.Error(codes.Unimplemented, "")
-	} else if contentSource != nil && contentSource.GetVolume() != nil {
-		return nil, status.Error(codes.Unimplemented, "")
-	} else {
-		// mark volume for leak protection if pvc gets deleted
-		// before the creation of pv.
-		var finishCreateVolume func()
-
-		if finishCreateVolume, err = cs.leakProtection.BeginCreateVolume(volName,
-			params.PVCNamespace, params.PVCName); err != nil {
-			return nil, err
-		}
-		defer finishCreateVolume()
-
-		vol, err = CreateLVMVolume(ctx, req, params)
-		if err != nil {
-			return nil, err
-		}
+	}
+	// mark volume for leak protection if pvc gets deleted
+	// before the creation of pv.
+	var finishCreateVolume func()
+	if finishCreateVolume, err = cs.leakProtection.BeginCreateVolume(volName,
+		params.PVCNamespace, params.PVCName); err != nil {
+		return nil, err
+	}
+	defer finishCreateVolume()
+	vol, err := CreateLVMVolume(ctx, req, params)
+	if err != nil {
+		return nil, err
 	}
 
 	sendEventOrIgnore(params.PVCName, volName,
@@ -628,6 +699,15 @@ func (cs *controller) CreateSnapshot(
 		WithVolGroup(vol.Spec.VolGroup).
 		Build()
 
+	if err != nil {
+		return nil, status.Errorf(
+			codes.Internal,
+			"failed to create snapshotobject for %s: %s, {%s}",
+			req.SourceVolumeId, req.Name,
+			err.Error(),
+		)
+	}
+
 	// the capacity of the snapshot will be set according to the params
 	// defined in the snapshot class
 	if snapSize > 0 {
@@ -637,6 +717,10 @@ func (cs *controller) CreateSnapshot(
 	} else if vol.Spec.ThinProvision != lvm.YES {
 		snapObj, err = snapbuilder.BuildFrom(snapObj).
 			WithSnapSize(vol.Spec.Capacity).
+			Build()
+	} else {
+		snapObj, err = snapbuilder.BuildFrom(snapObj).
+			WithThinProvision(true).
 			Build()
 	}
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -18,7 +18,7 @@ package driver
 
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"github.com/openebs/lvm-localpv/pkg/driver/config"
 )

--- a/pkg/driver/grpc.go
+++ b/pkg/driver/grpc.go
@@ -28,7 +28,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )

--- a/pkg/lvm/iolimiter.go
+++ b/pkg/lvm/iolimiter.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"github.com/openebs/lvm-localpv/pkg/driver/config"
 )

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -32,7 +32,7 @@ import (
 	"github.com/creack/pty"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	apis "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
 )

--- a/pkg/lvm/mount.go
+++ b/pkg/lvm/mount.go
@@ -27,7 +27,7 @@ import (
 	mnt "github.com/openebs/lib-csi/pkg/mount"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 	mount "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
 

--- a/pkg/lvm/volume.go
+++ b/pkg/lvm/volume.go
@@ -24,7 +24,7 @@ import (
 	"google.golang.org/grpc/status"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	apis "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
 	"github.com/openebs/lvm-localpv/pkg/builder/snapbuilder"

--- a/pkg/mgmt/lvmnode/start.go
+++ b/pkg/mgmt/lvmnode/start.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	"github.com/openebs/lvm-localpv/pkg/lvm"
 )

--- a/pkg/mgmt/snapshot/builder.go
+++ b/pkg/mgmt/snapshot/builder.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/mgmt/snapshot/snapshot.go
+++ b/pkg/mgmt/snapshot/snapshot.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	apis "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
 	"github.com/openebs/lvm-localpv/pkg/lvm"

--- a/pkg/mgmt/snapshot/start.go
+++ b/pkg/mgmt/snapshot/start.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 var (

--- a/pkg/mgmt/volume/builder.go
+++ b/pkg/mgmt/volume/builder.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 const (

--- a/pkg/mgmt/volume/start.go
+++ b/pkg/mgmt/volume/start.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 var (

--- a/pkg/mgmt/volume/volume.go
+++ b/pkg/mgmt/volume/volume.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 
 	apis "github.com/openebs/lvm-localpv/pkg/apis/openebs.io/lvm/v1alpha1"
 	"github.com/openebs/lvm-localpv/pkg/lvm"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -22,7 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"k8s.io/klog/v2"
+	klog "k8s.io/klog/v2"
 )
 
 var (


### PR DESCRIPTION
Why is this PR required?
This PR update new fields into LVM volume and snapshot CRD which is required for restore from snapshot.

**What this PR does?**:
- Add two new fields to the LVM Snapshot CR: **`thinProvision`** and **`lvSize`**.
    - **`thinProvision`**: Indicates whether the snapshot was created from a thin-provisioned volume.  
    - **`lvSize`**: Records the capacity of the snapshot lv at the time the snapshot was taken.
- Add a new field **`source`** to the LVM Volume CR. It defines the data source for the volume.
    - Can be a **snapshot**  
    - Or an **existing volume**
- Update snapshot and volume CRD yaml
- Validate restore from snapshot request.


**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:

