### PR TITLE
feat(scheduler): scheduler fixes and enhancements

### DIFF
--- a/deploy/helm/charts/charts/crds/templates/lvmnode.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmnode.yaml
@@ -14,7 +14,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.0
+    controller-gen.kubebuilder.io/version: v0.13.0
     {{- include "crds.extraAnnotations" .Values.lvmLocalPv | nindent 4 }}
   creationTimestamp: null
   name: lvmnodes.local.openebs.io
@@ -141,6 +141,36 @@ spec:
                   description: SnapCount denotes number of snapshots in volume group.
                   format: int32
                   type: integer
+                thinPools:
+                  description: ThinPools hosted by the volume group.
+                  items:
+                    description: ThinPool LV present on VG.
+                    properties:
+                      free:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Free capacity of thinpool. In bytes, if no unit
+                          specified.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name of the thinpool lv.
+                        type: string
+                      size:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Size of the thinpool lv. In bytes, if no unit
+                          specified.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - free
+                    - name
+                    - size
+                    type: object
+                  type: array
                 uuid:
                   description: UUID denotes a unique identity of a lvm volume group.
                   minLength: 1

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -439,24 +439,30 @@ spec:
                 thinPools:
                   description: ThinPools hosted by the volume group.
                   items:
+                    description: ThinPool LV present on VG.
                     properties:
-                      data_percent:
+                      free:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Used capacity of thinpool, in percent.
+                        description: Free capacity of thinpool. In bytes, if no unit
+                          specified.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      lv:
+                      name:
                         description: Name of the thinpool lv.
-                        minLength: 1
                         type: string
                       size:
-                        description: 'Size of the thinpool lv. Example: "10737418240B"'
-                        type: string
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Size of the thinpool lv. In bytes, if no unit
+                          specified.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
                     required:
-                    - data_percent
-                    - lv
+                    - free
+                    - name
                     - size
                     type: object
                   type: array
@@ -480,7 +486,6 @@ spec:
               - pvCount
               - size
               - snapCount
-              - thinPools
               - uuid
               type: object
             type: array

--- a/deploy/lvm-operator.yaml
+++ b/deploy/lvm-operator.yaml
@@ -436,6 +436,30 @@ spec:
                   description: SnapCount denotes number of snapshots in volume group.
                   format: int32
                   type: integer
+                thinPools:
+                  description: ThinPools hosted by the volume group.
+                  items:
+                    properties:
+                      data_percent:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Used capacity of thinpool, in percent.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      lv:
+                        description: Name of the thinpool lv.
+                        minLength: 1
+                        type: string
+                      size:
+                        description: 'Size of the thinpool lv. Example: "10737418240B"'
+                        type: string
+                    required:
+                    - data_percent
+                    - lv
+                    - size
+                    type: object
+                  type: array
                 uuid:
                   description: UUID denotes a unique identity of a lvm volume group.
                   minLength: 1
@@ -456,6 +480,7 @@ spec:
               - pvCount
               - size
               - snapCount
+              - thinPools
               - uuid
               type: object
             type: array

--- a/deploy/yamls/lvmnode-crd.yaml
+++ b/deploy/yamls/lvmnode-crd.yaml
@@ -1,8 +1,6 @@
-
-
 ##############################################
 ###########                       ############
-###########     LVMNode CRD       ############
+###########   LVMNode CRD     ############
 ###########                       ############
 ##############################################
 
@@ -158,6 +156,34 @@ spec:
                   description: SnapCount denotes number of snapshots in volume group.
                   format: int32
                   type: integer
+                thinPools:
+                  description: ThinPools hosted by the volume group.
+                  items:
+                    description: ThinPool LV present on VG.
+                    properties:
+                      free:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Free capacity of the thinpool lv. In bytes, if no unit specified.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                      name:
+                        description: Name of the thinpool lv.
+                        type: string
+                      size:
+                        anyOf:
+                        - type: integer
+                        - type: string
+                        description: Size of the thinpool lv. In bytes, if no unit specified.
+                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                        x-kubernetes-int-or-string: true
+                    required:
+                    - free
+                    - name
+                    - size
+                    type: object
+                  type: array
                 uuid:
                   description: UUID denotes a unique identity of a lvm volume group.
                   minLength: 1

--- a/deploy/yamls/lvmnode-crd.yaml
+++ b/deploy/yamls/lvmnode-crd.yaml
@@ -1,6 +1,8 @@
+
+
 ##############################################
 ###########                       ############
-###########   LVMNode CRD     ############
+###########     LVMNode CRD       ############
 ###########                       ############
 ##############################################
 
@@ -165,7 +167,8 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Free capacity of the thinpool lv. In bytes, if no unit specified.
+                        description: Free capacity of thinpool. In bytes, if no unit
+                          specified.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                       name:
@@ -175,7 +178,8 @@ spec:
                         anyOf:
                         - type: integer
                         - type: string
-                        description: Size of the thinpool lv. In bytes, if no unit specified.
+                        description: Size of the thinpool lv. In bytes, if no unit
+                          specified.
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
                     required:

--- a/pkg/apis/openebs.io/lvm/v1alpha1/lvmnode.go
+++ b/pkg/apis/openebs.io/lvm/v1alpha1/lvmnode.go
@@ -112,6 +112,22 @@ type VolumeGroup struct {
 	// int and string for its value:
 	// [-1: "", 0: "normal", 1: "contiguous", 2: "cling", 3: "anywhere", 4: "inherited"]
 	AllocationPolicy int `json:"allocationPolicy"`
+
+	// ThinPools hosted by the volume group.
+	ThinPools []ThinPool `json:"thinPools,omitempty"`
+}
+
+// ThinPool LV present on VG.
+type ThinPool struct {
+	// Name of the thinpool lv.
+	// +kubebuilder:validation:Required
+	Name string `json:"name"`
+	// Size of the thinpool lv. In bytes, if no unit specified.
+	// +kubebuilder:validation:Required
+	Size resource.Quantity `json:"size"`
+	// Free capacity of thinpool. In bytes, if no unit specified.
+	// +kubebuilder:validation:Required
+	Free resource.Quantity `json:"free"`
 }
 
 // LVMNodeList is a collection of LVMNode resources

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -285,7 +285,6 @@ func CreateLVMVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 	volName := strings.ToLower(req.GetName())
 	capacity := strconv.FormatInt(getRoundedCapacity(
 		req.GetCapacityRange().RequiredBytes), 10)
-
 	vol, err := lvm.GetLVMVolume(volName)
 	if err != nil {
 		if !k8serror.IsNotFound(err) {
@@ -338,25 +337,24 @@ func CreateLVMVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 		owner = lvmSnapCr.Spec.OwnerNodeID
 		lvmSnapshotCrName = lvmSnapCr.Name
 		volGroup = lvmSnapCr.Spec.VolGroup
-	}
-
-	// if owner is not already set from snapshot, run the scheduler
-	// to select the owner node for the volume
-	if owner == "" {
-		nmap, err := getNodeMap(params.Scheduler, params.VgPattern)
+	} else {
+		nmap, err := getNodeMap(params, capacity)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "get node map failed : %s", err.Error())
 		}
 
+		if len(nmap) == 0 {
+			return nil, status.Error(codes.ResourceExhausted, "Could not find suitable node to schedule the PVC")
+		}
+
 		// run the scheduler
 		selected := schd.Scheduler(req, nmap)
+
 		if len(selected) == 0 {
-			return nil, status.Error(codes.Internal, "scheduler failed, not able to select a node to create the PV")
+			return nil, status.Error(codes.ResourceExhausted, "scheduler failed, not able to select a node to create the PV")
 		}
 
 		owner = selected[0]
-		klog.Infof("scheduling the volume %s/%s on node %s",
-			params.VgPattern.String(), volName, owner)
 	}
 
 	volObj, err := volbuilder.NewBuilder().

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -63,7 +63,7 @@ func getVolumeWeightedMap(params *VolumeParams, capacity string) (map[string]int
 	}
 
 	for _, node := range nodeList.Items {
-		if !(params.ThinProvision == "yes") && !slices.Contains(suitableNodes, node.Name) {
+		if params.ThinProvision != lvm.YES && !slices.Contains(suitableNodes, node.Name) {
 			continue
 		}
 		for _, vg := range node.VolumeGroups {
@@ -99,7 +99,7 @@ func getCapacityWeightedMap(params *VolumeParams, capacity string) (map[string]i
 	}
 
 	for _, node := range nodeList.Items {
-		if !(params.ThinProvision == "yes") && !slices.Contains(suitableNodes, node.Name) {
+		if params.ThinProvision != lvm.YES && !slices.Contains(suitableNodes, node.Name) {
 			continue
 		}
 		for _, vg := range node.VolumeGroups {
@@ -112,7 +112,7 @@ func getCapacityWeightedMap(params *VolumeParams, capacity string) (map[string]i
 	return nmap, nil
 }
 
-// Goes through all volume groups in the node to determine vg with higest
+// Goes through all volume groups in the node to determine vg with highest
 // free space. In case of thick volume, We discard node in case it has
 // no Volume group that can accommodate it.
 func getSpaceWeightedMap(params *VolumeParams, capacity string) (map[string]int64, error) {
@@ -131,6 +131,13 @@ func getSpaceWeightedMap(params *VolumeParams, capacity string) (map[string]int6
 		for _, vg := range node.VolumeGroups {
 			if params.VgPattern.MatchString(vg.Name) {
 				freeCapacity := vg.Free.Value()
+				if params.ThinProvision == lvm.YES {
+					for _, thinpool := range vg.ThinPools {
+						if thinpool.Name == vg.Name+"_thinpool" {
+							freeCapacity += thinpool.Free.Value()
+						}
+					}
+				}
 				if maxFree < freeCapacity {
 					maxFree = freeCapacity
 				}
@@ -141,7 +148,7 @@ func getSpaceWeightedMap(params *VolumeParams, capacity string) (map[string]int6
 			if err != nil {
 				return nmap, err
 			}
-			if !(params.ThinProvision == "yes") && pvcSize > maxFree {
+			if params.ThinProvision != lvm.YES && pvcSize > maxFree {
 				continue
 			}
 			// To implement SpaceWeighted scheduling, we invert the free space metric by subtracting

--- a/pkg/driver/schd_helper.go
+++ b/pkg/driver/schd_helper.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/strings/slices"
 
 	"github.com/openebs/lvm-localpv/pkg/builder/nodebuilder"
-	"github.com/openebs/lvm-localpv/pkg/builder/volbuilder"
 	"github.com/openebs/lvm-localpv/pkg/lvm"
 )
 
@@ -41,14 +41,14 @@ const (
 	SpaceWeighted = "SpaceWeighted"
 )
 
-// getVolumeWeightedMap goes through all the volumegroup on all the nodes
-// and creates the node mapping of the volume for all the nodes.
-// It returns a map which has nodes as key and volumes present
-// on the nodes as corresponding value.
-func getVolumeWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
+// Goes through all the volumegroup on all the nodes
+// and returns a map which has nodes as key and number of volumes present
+// on the nodes as corresponding value. In case of thick volume, We discard node
+// in case it has no Volume group that can accommodate it.
+func getVolumeWeightedMap(params *VolumeParams, capacity string) (map[string]int64, error) {
 	nmap := map[string]int64{}
 
-	vollist, err := volbuilder.NewKubeclient().
+	nodeList, err := nodebuilder.NewKubeclient().
 		WithNamespace(lvm.LvmNamespace).
 		List(metav1.ListOptions{})
 
@@ -56,40 +56,19 @@ func getVolumeWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
 		return nmap, err
 	}
 
-	// create the map of the volume count
-	// for the given vg
-	for _, vol := range vollist.Items {
-		if re.MatchString(vol.Spec.VolGroup) {
-			nmap[vol.Spec.OwnerNodeID]++
+	suitableNodes, err := getSuitableNodes(params.VgPattern, capacity)
+
+	if err != nil {
+		return nmap, err
+	}
+
+	for _, node := range nodeList.Items {
+		if !(params.ThinProvision == "yes") && !slices.Contains(suitableNodes, node.Name) {
+			continue
 		}
-	}
-
-	return nmap, nil
-}
-
-// getCapacityWeightedMap goes through all the volume groups on all the nodes
-// and creates the node mapping of the capacity for all the nodes.
-// It returns a map which has nodes as key and capacity provisioned
-// on the nodes as corresponding value. The scheduler will use this map
-// and picks the node which is less weighted.
-func getCapacityWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
-	nmap := map[string]int64{}
-
-	volList, err := volbuilder.NewKubeclient().
-		WithNamespace(lvm.LvmNamespace).
-		List(metav1.ListOptions{})
-
-	if err != nil {
-		return nmap, err
-	}
-
-	// create the map of the volume capacity
-	// for the given volume group
-	for _, vol := range volList.Items {
-		if re.MatchString(vol.Spec.VolGroup) {
-			volSize, err := strconv.ParseInt(vol.Spec.Capacity, 10, 64)
-			if err == nil {
-				nmap[vol.Spec.OwnerNodeID] += volSize
+		for _, vg := range node.VolumeGroups {
+			if params.VgPattern.MatchString(vg.Name) {
+				nmap[node.Name] += int64(vg.LVCount)
 			}
 		}
 	}
@@ -97,10 +76,46 @@ func getCapacityWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
 	return nmap, nil
 }
 
-// getSpaceWeightedMap returns how weighted a node is space wise.
-// The node which has max free space available is less loaded and
-// can accumulate more volumes.
-func getSpaceWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
+// Goes through all the volume groups on all the nodes
+// and returns a map which has nodes as key and capacity provisioned
+// on the nodes as corresponding value. The scheduler will use this map
+// and picks the node which is less weighted. In case of thick volume, We discard node
+// in case it has no Volume group that can accommodate it.
+func getCapacityWeightedMap(params *VolumeParams, capacity string) (map[string]int64, error) {
+	nmap := map[string]int64{}
+
+	nodeList, err := nodebuilder.NewKubeclient().
+		WithNamespace(lvm.LvmNamespace).
+		List(metav1.ListOptions{})
+
+	if err != nil {
+		return nmap, err
+	}
+
+	suitableNodes, err := getSuitableNodes(params.VgPattern, capacity)
+
+	if err != nil {
+		return nmap, err
+	}
+
+	for _, node := range nodeList.Items {
+		if !(params.ThinProvision == "yes") && !slices.Contains(suitableNodes, node.Name) {
+			continue
+		}
+		for _, vg := range node.VolumeGroups {
+			if params.VgPattern.MatchString(vg.Name) {
+				nmap[node.Name] += vg.Size.Value() - vg.Free.Value()
+			}
+		}
+	}
+
+	return nmap, nil
+}
+
+// Goes through all volume groups in the node to determine vg with higest
+// free space. In case of thick volume, We discard node in case it has
+// no Volume group that can accommodate it.
+func getSpaceWeightedMap(params *VolumeParams, capacity string) (map[string]int64, error) {
 	nmap := map[string]int64{}
 
 	nodeList, err := nodebuilder.NewKubeclient().
@@ -114,7 +129,7 @@ func getSpaceWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
 	for _, node := range nodeList.Items {
 		var maxFree int64 = 0
 		for _, vg := range node.VolumeGroups {
-			if re.MatchString(vg.Name) {
+			if params.VgPattern.MatchString(vg.Name) {
 				freeCapacity := vg.Free.Value()
 				if maxFree < freeCapacity {
 					maxFree = freeCapacity
@@ -122,8 +137,16 @@ func getSpaceWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
 			}
 		}
 		if maxFree > 0 {
-			// converting to SpaceWeighted by subtracting it with MaxInt64
-			// as the node which has max free space available is less loaded.
+			pvcSize, err := strconv.ParseInt(capacity, 10, 64)
+			if err != nil {
+				return nmap, err
+			}
+			if !(params.ThinProvision == "yes") && pvcSize > maxFree {
+				continue
+			}
+			// To implement SpaceWeighted scheduling, we invert the free space metric by subtracting
+			// the node's free space from math.MaxInt64. This way, nodes with more free space will have
+			// lower weights, making them preferred by the scheduler as less loaded nodes.
 			nmap[node.Name] = math.MaxInt64 - maxFree
 		}
 	}
@@ -131,16 +154,44 @@ func getSpaceWeightedMap(re *regexp.Regexp) (map[string]int64, error) {
 	return nmap, nil
 }
 
+// Returns nodes which can accommodate a requested capacity.
+func getSuitableNodes(reg *regexp.Regexp, capacity string) ([]string, error) {
+	var nodes []string
+	nodeList, err := nodebuilder.NewKubeclient().
+		WithNamespace(lvm.LvmNamespace).
+		List(metav1.ListOptions{})
+
+	if err != nil {
+		return nodes, err
+	}
+	for _, node := range nodeList.Items {
+		var maxFree int64 = 0
+		for _, vg := range node.VolumeGroups {
+			if reg.MatchString(vg.Name) && vg.Free.Value() > maxFree {
+				maxFree = vg.Free.Value()
+			}
+		}
+		pvcSize, err := strconv.ParseInt(capacity, 10, 64)
+		if err != nil {
+			return nodes, err
+		}
+		if maxFree > pvcSize {
+			nodes = append(nodes, node.Name)
+		}
+	}
+	return nodes, nil
+}
+
 // getNodeMap returns the node mapping for the given scheduling algorithm
-func getNodeMap(schd string, vgPattern *regexp.Regexp) (map[string]int64, error) {
-	switch schd {
+func getNodeMap(params *VolumeParams, capacity string) (map[string]int64, error) {
+	switch params.Scheduler {
 	case VolumeWeighted:
-		return getVolumeWeightedMap(vgPattern)
+		return getVolumeWeightedMap(params, capacity)
 	case CapacityWeighted:
-		return getCapacityWeightedMap(vgPattern)
+		return getCapacityWeightedMap(params, capacity)
 	case SpaceWeighted:
-		return getSpaceWeightedMap(vgPattern)
+		return getSpaceWeightedMap(params, capacity)
 	}
 	// return getSpaceWeightedMap(default) if not specified
-	return getSpaceWeightedMap(vgPattern)
+	return getSpaceWeightedMap(params, capacity)
 }

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -970,7 +970,7 @@ func parseVolumeGroup(m map[string]string) (apis.VolumeGroup, error) {
 	for key, value := range int32Map {
 		count, err = strconv.Atoi(m[key])
 		if err != nil {
-			err = fmt.Errorf("invalid format of %v=%v for vg %v: %v", key, m[key], vg.Name, err)
+			return vg, fmt.Errorf("invalid format of %v=%v for vg %v: %v", key, m[key], vg.Name, err)
 		}
 		*value = int32(count)
 	}
@@ -987,7 +987,7 @@ func parseVolumeGroup(m map[string]string) (apis.VolumeGroup, error) {
 			strings.TrimSuffix(strings.ToLower(m[key]), "b"),
 			10, 64)
 		if err != nil {
-			err = fmt.Errorf("invalid format of %v=%v for vg %v: %v", key, m[key], vg.Name, err)
+			return vg, fmt.Errorf("invalid format of %v=%v for vg %v: %v", key, m[key], vg.Name, err)
 		}
 		quantity := resource.NewQuantity(sizeBytes, resource.BinarySI)
 		*value = *quantity //
@@ -995,8 +995,80 @@ func parseVolumeGroup(m map[string]string) (apis.VolumeGroup, error) {
 
 	vg.Permission = getIntFieldValue(VGPermissions, m[VGPermissions])
 	vg.AllocationPolicy = getIntFieldValue(VGAllocationPolicy, m[VGAllocationPolicy])
+	vg.ThinPools, err = getThinPools(vg.Name)
+	if err != nil {
+		return vg, fmt.Errorf("%s", err)
+	}
+	return vg, nil
+}
 
-	return vg, err
+// Returns thinpools present on the VG.
+func getThinPools(vg string) ([]apis.ThinPool, error) {
+	var thinpools []apis.ThinPool
+	var err error
+
+	args := []string{
+		"--reportformat", "json",
+		"--units", "b", "--no-suffix",
+	}
+	output, _, err := RunCommandSplit(LVList, args...)
+	if err != nil {
+		klog.Errorf("lvm: error while running command %s %v: %v", LVList, args, err)
+		return nil, err
+	}
+
+	var lvsReport struct {
+		Report []struct {
+			Lv []struct {
+				LvName      string `json:"lv_name"`
+				VgName      string `json:"vg_name"`
+				LvAttr      string `json:"lv_attr"`
+				LvSize      string `json:"lv_size"`
+				DataPercent string `json:"data_percent"`
+			} `json:"lv"`
+		} `json:"report"`
+	}
+
+	if err := json.Unmarshal(output, &lvsReport); err != nil {
+		fmt.Println("error in unmarshal")
+		return nil, fmt.Errorf("couldn't unmarshal lvs resonse: %s", vg)
+	}
+
+	for _, report := range lvsReport.Report {
+		for _, lv := range report.Lv {
+			if strings.HasPrefix(lv.LvAttr, "t") && lv.VgName == vg {
+				size, err := strconv.ParseInt(lv.LvSize, 10, 64)
+				size_quantity := resource.NewQuantity(size, resource.BinarySI)
+				if err != nil {
+					return nil, fmt.Errorf("couldn't convert size %s into integer", lv.LvSize)
+				}
+				free, err := getThinPoolFree(size, lv.DataPercent)
+				if err != nil {
+					return nil, fmt.Errorf("couldn't get free size for vg %s, err %v", lv.LvName, err)
+				}
+				free_quantity := resource.NewQuantity(free, resource.BinarySI)
+
+				thinpools = append(thinpools, apis.ThinPool{
+					Name: lv.LvName,
+					Size: *size_quantity,
+					Free: *free_quantity,
+				})
+			}
+		}
+	}
+	return thinpools, nil
+}
+
+// Returns thinpool free space in bytes.
+func getThinPoolFree(size int64, usedPercent string) (int64, error) {
+	usedFloat, err := strconv.ParseFloat(usedPercent, 32)
+	if err != nil {
+		return 0, fmt.Errorf("couldn't convert data_percent %s into float", usedPercent)
+	}
+	usedFraction := usedFloat / 100
+	used := float64(size) * usedFraction
+	free := size - int64(used)
+	return free, nil
 }
 
 // This function returns the integer equivalent for different string values for the LVM component(vg,lv) field.

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -38,7 +38,7 @@ func IsPVCBoundEventually(pvcName string) bool {
 		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		return pvc.NewForAPIObject(volume).IsBound()
 	},
-		60, 5).
+		120, 5).
 		Should(gomega.BeTrue())
 }
 


### PR DESCRIPTION
This PR

Adds thinPools object into lvmNode CRD inside volumeGroup.
Adds logic to fetch and patch thinPool information into volumeGroup.

Fail fast CreateVolume request if thick PVC size cannot be accommodated by any VG.

Considers thinpool free space while scheduling thin pvc in SpaceWeighted algorithm