### PR TITLE
feat(restore): create LVM volume from thin snapshot as source

### DIFF
--- a/buildscripts/lvm-driver/Dockerfile
+++ b/buildscripts/lvm-driver/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine:3.22.1
 RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
-RUN apk add --no-cache btrfs-progs xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
+RUN apk add --no-cache btrfs-progs btrfs-progs-extra xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates libc6-compat
 
 ARG DBUILD_DATE

--- a/buildscripts/lvm-driver/Dockerfile
+++ b/buildscripts/lvm-driver/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM alpine:3.22.1
 RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
-RUN apk add --no-cache btrfs-progs btrfs-progs-extra xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
+RUN apk add --no-cache btrfs-progs-extra xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates libc6-compat
 
 ARG DBUILD_DATE

--- a/buildscripts/lvm-driver/Dockerfile.buildx
+++ b/buildscripts/lvm-driver/Dockerfile.buildx
@@ -43,7 +43,7 @@ RUN make buildx.csi-driver
 
 FROM alpine:3.22.1
 RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
-RUN apk add --no-cache btrfs-progs btrfs-progs-extra xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
+RUN apk add --no-cache btrfs-progs-extra xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates
 
 ARG DBUILD_DATE

--- a/buildscripts/lvm-driver/Dockerfile.buildx
+++ b/buildscripts/lvm-driver/Dockerfile.buildx
@@ -43,7 +43,7 @@ RUN make buildx.csi-driver
 
 FROM alpine:3.22.1
 RUN apk add --no-cache lvm2 lvm2-extra util-linux device-mapper
-RUN apk add --no-cache btrfs-progs xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
+RUN apk add --no-cache btrfs-progs btrfs-progs-extra xfsprogs xfsprogs-extra e2fsprogs e2fsprogs-extra
 RUN apk add --no-cache ca-certificates
 
 ARG DBUILD_DATE

--- a/deploy/helm/charts/charts/crds/templates/lvmsnapshot.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmsnapshot.yaml
@@ -56,6 +56,10 @@ spec:
               snapSize:
                 description: SnapSize specifies the space reserved for the snapshot
                 type: string
+              thinProvision:
+                description: ThinProvision specifies whether the snapshot is thin-provisioned
+                  or not.
+                type: boolean
               volGroup:
                 description: VolGroup specifies the name of the volume group where
                   the snapshot has been created.
@@ -68,6 +72,14 @@ spec:
             description: SnapStatus string that reflects if the snapshot was created
               successfully
             properties:
+              lvSize:
+                anyOf:
+                - type: integer
+                - type: string
+                description: LvSize specifies the size allocated for the snapshot
+                  in the VG
+                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                x-kubernetes-int-or-string: true
               state:
                 type: string
             type: object

--- a/deploy/helm/charts/charts/crds/templates/lvmvolume.yaml
+++ b/deploy/helm/charts/charts/crds/templates/lvmvolume.yaml
@@ -88,6 +88,13 @@ spec:
                 - "yes"
                 - "no"
                 type: string
+              source:
+                description: |-
+                  Source defines the data source from which the volume should be created.
+                  It can reference either a snapshot or an existing volume.
+                  If not specified, a standard LVM volume will be created.
+                  If specified, the new volume will be created using the defined data source.
+                type: string
               thinProvision:
                 description: ThinProvision specifies whether logical volumes can be
                   thinly provisioned. If it is set to "yes", then the LVM LocalPV

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -57,6 +57,7 @@ const (
 	LVCreate = "lvcreate"
 	LVRemove = "lvremove"
 	LVExtend = "lvextend"
+	LVChange = "lvchange"
 	LVList   = "lvs"
 
 	PVList = "pvs"
@@ -265,6 +266,38 @@ func buildLVMDestroyArgs(vol *apis.LVMVolume) []string {
 	return LVMVolArg
 }
 
+// buildLVMRestoreThinSnapshotArgs returns lvcreate command for the retore volume from thin snapshot
+func buildLVMRestoreThinSnapshotArgs(vol *apis.LVMVolume) []string {
+	var LVMRestoreThinVolArg []string
+
+	// command to create restored thin volume from thin snapshot
+	// `lvcreate -s -n <restore-volume-name>  lvmvg/<thin-snapshot-id>`
+	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-s", "-n", vol.Name)
+
+	if len(vol.Spec.VolGroup) != 0 {
+		LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, vol.Spec.VolGroup+"/"+getLVMSnapName(vol.Spec.Source))
+	}
+
+	// -y is used to wipe the signatures before creating LVM volume
+	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-y")
+	return LVMRestoreThinVolArg
+}
+
+// buildLVMVolumeActivateArgs returns lvchnage command to activate the volume
+func buildLVMVolumeActivateArgs(vol *apis.LVMVolume) []string {
+	var LVMActivateVolArg []string
+
+	// command to activate volume
+	// `lvchange -kn -ay  lvmvg/<volume-name>`
+	LVMActivateVolArg = append(LVMActivateVolArg, "-kn", "-ay")
+
+	if len(vol.Spec.VolGroup) != 0 {
+		LVMActivateVolArg = append(LVMActivateVolArg, vol.Spec.VolGroup+"/"+vol.Name)
+	}
+
+	return LVMActivateVolArg
+}
+
 // RunCommandSplit is a wrapper function to run a command and receive its
 // STDERR and STDOUT streams in separate []byte vars.
 func RunCommandSplit(command string, args ...string) ([]byte, []byte, error) {
@@ -299,6 +332,45 @@ func CreateVolume(vol *apis.LVMVolume) error {
 		return nil
 	}
 
+	// Handle volume creation based on source
+	if vol.Spec.Source != "" {
+		// check if the source is snapshot
+		if !strings.HasPrefix(vol.Spec.Source, "snapshot-") {
+			return fmt.Errorf("unsupported source %s; only snapshot source is supported", vol.Spec.Source)
+		}
+
+		snapName := getLVMSnapName(vol.Spec.Source)
+		if exists, err := isSnapshotExists(vol.Spec.VolGroup, snapName); err != nil {
+			return fmt.Errorf("failed to check snapshot existence: %w", err)
+		} else if !exists {
+			return fmt.Errorf("snapshot %s does not exist in volume group %s", snapName, vol.Spec.VolGroup)
+		}
+
+		// Create volume from thin snapshot
+		args := buildLVMRestoreThinSnapshotArgs(vol)
+		out, _, err := RunCommandSplit(LVCreate, args...)
+		if err != nil {
+			err = newExecError(out, err)
+			klog.Errorf(
+				"lvm: could not create snapshot %v cmd %v error: %s", volume, args, string(out),
+			)
+			return err
+		}
+
+		// Activate the restored thin volume
+		activateArgs := buildLVMVolumeActivateArgs(vol)
+		out, _, err = RunCommandSplit(LVChange, activateArgs...)
+		if err != nil {
+			err = newExecError(out, err)
+			klog.Errorf(
+				"lvm: could not activate volume %v cmd %v error: %s", volume, args, string(out),
+			)
+			return err
+		}
+
+		klog.Infof("lvm: created restored volume %s from thin snapshot %s as source", volume, snapName)
+		return nil
+	}
 	args := buildLVMCreateArgs(vol)
 	out, _, err := RunCommandSplit(LVCreate, args...)
 

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -266,25 +266,25 @@ func buildLVMDestroyArgs(vol *apis.LVMVolume) []string {
 	return LVMVolArg
 }
 
-// buildLVMRestoreThinSnapshotArgs returns lvcreate command for the retore volume from thin snapshot
+// buildLVMRestoreThinSnapshotArgs returns lvcreate command for the restore volume from thin snapshot
 func buildLVMRestoreThinSnapshotArgs(vol *apis.LVMVolume) []string {
 	var LVMRestoreThinVolArg []string
 
 	// command to create restored thin volume from thin snapshot
-	// `lvcreate -s -n <restore-volume-name>  lvmvg/<thin-snapshot-id> -y`
+	// `lvcreate -s -n <restore-volume-name>  lvmvg/<thin-snapshot-name> -y --wipesignatures n`
 	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-s", "-n", vol.Name)
 
 	if len(vol.Spec.VolGroup) != 0 {
 		LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, vol.Spec.VolGroup+"/"+getLVMSnapName(vol.Spec.Source))
 	}
 
-	// -y option automatically answers "yes" to any prompts, which may include prompts related to wiping
-	// signatures if LVM detects existing filesystem or other signatures on the underlying storage
-	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-y")
+	// -y to automatically answer "yes" to all non-signature prompts and
+	// --wipesignatures n explicitly prevent wiping any detected filesystem or metadata signatures.
+	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-y", "--wipesignatures", "n")
 	return LVMRestoreThinVolArg
 }
 
-// buildLVMVolumeActivateArgs returns lvchnage command to activate the volume
+// buildLVMVolumeActivateArgs returns lvchange command to activate the volume
 func buildLVMVolumeActivateArgs(vol *apis.LVMVolume) []string {
 	var LVMActivateVolArg []string
 

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -271,14 +271,15 @@ func buildLVMRestoreThinSnapshotArgs(vol *apis.LVMVolume) []string {
 	var LVMRestoreThinVolArg []string
 
 	// command to create restored thin volume from thin snapshot
-	// `lvcreate -s -n <restore-volume-name>  lvmvg/<thin-snapshot-id>`
+	// `lvcreate -s -n <restore-volume-name>  lvmvg/<thin-snapshot-id> -y`
 	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-s", "-n", vol.Name)
 
 	if len(vol.Spec.VolGroup) != 0 {
 		LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, vol.Spec.VolGroup+"/"+getLVMSnapName(vol.Spec.Source))
 	}
 
-	// -y is used to wipe the signatures before creating LVM volume
+	// -y option automatically answers "yes" to any prompts, which may include prompts related to wiping
+	// signatures if LVM detects existing filesystem or other signatures on the underlying storage
 	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-y")
 	return LVMRestoreThinVolArg
 }

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -736,7 +736,7 @@ func ResizeLVMVolume(vol *apis.LVMVolume, resizefs bool) error {
 			return err
 		}
 
-		curVolSize, err := getLVSize(vol)
+		curVolSize, err := getLVSize(vol.Name, vol.Spec.VolGroup)
 		if err != nil {
 			return err
 		}
@@ -768,8 +768,8 @@ func ResizeLVMVolume(vol *apis.LVMVolume, resizefs bool) error {
 }
 
 // getLVSize will return current LVM volume size in bytes
-func getLVSize(vol *apis.LVMVolume) (uint64, error) {
-	lvmVolumeName := vol.Spec.VolGroup + "/" + vol.Name
+func getLVSize(lvName, volGroup string) (uint64, error) {
+	lvmVolumeName := volGroup + "/" + lvName
 
 	args := []string{
 		lvmVolumeName,

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -30,6 +30,8 @@ import (
 	"time"
 
 	"github.com/creack/pty"
+	"github.com/openebs/lib-csi/pkg/btrfs"
+	"github.com/openebs/lib-csi/pkg/xfs"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	klog "k8s.io/klog/v2"
@@ -49,7 +51,6 @@ const (
 	BlockCleanerCommand = "wipefs"
 	// Block ID
 	BlockIdCommand = "blkid"
-
 	// btrfs tune command to change UUID
 	BtrfstuneCommand = "btrfstune"
 	// xfs admin command to change UUID
@@ -285,6 +286,7 @@ func buildLVMRestoreThinSnapshotArgs(vol *apis.LVMVolume) []string {
 	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, vol.Spec.VolGroup+"/"+getLVMSnapName(vol.Spec.Source))
 
 	// -y to automatically answer "yes" to all prompts
+	// wipesignatures being skipped as it's not supported with snapshot
 	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-y")
 	return LVMRestoreThinVolArg
 }
@@ -1478,14 +1480,14 @@ func updateVolumeUuid(lvmVolume *apis.LVMVolume) error {
 	// update volume UUID based on filesystem type
 	switch fsType {
 	case "btrfs":
-		err := updateBtrfsUUID(devicePath)
+		err := btrfs.GenerateUUID(devicePath)
 		if err != nil {
 			klog.Errorf("failed to update device btrfs filesystem %s UUID, error: %v", devicePath, err)
 			return err
 		}
 		klog.Infof("Successfully updated btrfs filesystem UUID for device %s", devicePath)
 	case "xfs":
-		err := updateXfsUUID(devicePath)
+		err := xfs.GenerateUUID(devicePath)
 		if err != nil {
 			klog.Errorf("failed to update device xfs filesystem %s UUID, error: %v", devicePath, err)
 			return err
@@ -1509,49 +1511,4 @@ func detectFsType(devicePath string) (string, error) {
 	}
 	klog.V(4).Infof("Successfully fetched device %s TYPE %s", devicePath, strings.TrimSpace(string(out)))
 	return strings.TrimSpace(string(out)), nil
-}
-
-// updateBtrfsUUID update UUID of btrfs filesystem for given device path
-// command: yes | btrfstune -u /dev/lvmvg/pvc-d16fa9be-806d-4eb2-ae80-fd35e67a3483
-func updateBtrfsUUID(devicePath string) error {
-	cmd := exec.Command(BtrfstuneCommand, "-u", devicePath)
-	// Get stdin pipe to send response
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return fmt.Errorf("failed to get stdin pipe: %w", err)
-	}
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	// Start the command
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start btrfstune: %w", err)
-	}
-	// Send EXACTLY "y" to stdin to confirm UUID change
-	_, err = stdin.Write([]byte("y"))
-	if err != nil {
-		_ = cmd.Process.Kill()
-		return fmt.Errorf("failed to send 'y': %v", err)
-	}
-	stdin.Close() // Critical: unblocks the process
-	// Wait for completion
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("btrfstune failed: %v\nOutput: %s", err, out.String())
-	}
-	klog.V(4).Infof("Btrfs UUID updated: %s", out.String())
-	return nil
-}
-
-// updateXfsUUID updates the UUID of an XFS filesystem using xfs_admin -U generate
-// command: xfs_admin -U generate: generates and applies a new UUID directly
-func updateXfsUUID(devicePath string) error {
-	cmd := exec.Command(XFSAdminCommand, "-U", "generate", devicePath)
-	// Capture both stdout and stderr
-	output, err := cmd.CombinedOutput()
-	outStr := strings.TrimSpace(string(output))
-	if err != nil {
-		return fmt.Errorf("xfs_admin failed on %s: %w\nOutput: %s", devicePath, err, outStr)
-	}
-	klog.V(4).Infof("XFS UUID updated: %s", outStr)
-	return nil
 }

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -47,6 +47,13 @@ const (
 
 	// BlockCleanerCommand is the command used to clean filesystem on the device
 	BlockCleanerCommand = "wipefs"
+	// Block ID
+	BlockIdCommand = "blkid"
+
+	// btrfs tune command to change UUID
+	BtrfstuneCommand = "btrfstune"
+	// xfs admin command to change UUID
+	XFSAdminCommand = "xfs_admin"
 )
 
 // lvm command related constants
@@ -271,16 +278,14 @@ func buildLVMRestoreThinSnapshotArgs(vol *apis.LVMVolume) []string {
 	var LVMRestoreThinVolArg []string
 
 	// command to create restored thin volume from thin snapshot
-	// `lvcreate -s -n <restore-volume-name>  lvmvg/<thin-snapshot-name> -y --wipesignatures n`
+	// `lvcreate -s -n <restore-volume-name>  lvmvg/<thin-snapshot-name> -y`
 	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-s", "-n", vol.Name)
 
-	if len(vol.Spec.VolGroup) != 0 {
-		LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, vol.Spec.VolGroup+"/"+getLVMSnapName(vol.Spec.Source))
-	}
+	// update args with <volgroup>/<thin-snapshot-name>
+	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, vol.Spec.VolGroup+"/"+getLVMSnapName(vol.Spec.Source))
 
-	// -y to automatically answer "yes" to all non-signature prompts and
-	// --wipesignatures n explicitly prevent wiping any detected filesystem or metadata signatures.
-	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-y", "--wipesignatures", "n")
+	// -y to automatically answer "yes" to all prompts
+	LVMRestoreThinVolArg = append(LVMRestoreThinVolArg, "-y")
 	return LVMRestoreThinVolArg
 }
 
@@ -292,9 +297,8 @@ func buildLVMVolumeActivateArgs(vol *apis.LVMVolume) []string {
 	// `lvchange -kn -ay  lvmvg/<volume-name>`
 	LVMActivateVolArg = append(LVMActivateVolArg, "-kn", "-ay")
 
-	if len(vol.Spec.VolGroup) != 0 {
-		LVMActivateVolArg = append(LVMActivateVolArg, vol.Spec.VolGroup+"/"+vol.Name)
-	}
+	// update args with <volgroup>/<volume-name>
+	LVMActivateVolArg = append(LVMActivateVolArg, vol.Spec.VolGroup+"/"+vol.Name)
 
 	return LVMActivateVolArg
 }
@@ -335,6 +339,10 @@ func CreateVolume(vol *apis.LVMVolume) error {
 
 	// Handle volume creation based on source
 	if vol.Spec.Source != "" {
+		if len(vol.Spec.VolGroup) == 0 {
+			return fmt.Errorf("volGroup should be set for lvm volume %s CR", vol.Name)
+		}
+
 		// check if the source is snapshot
 		if !strings.HasPrefix(vol.Spec.Source, "snapshot-") {
 			return fmt.Errorf("unsupported source %s; only snapshot source is supported", vol.Spec.Source)
@@ -353,7 +361,7 @@ func CreateVolume(vol *apis.LVMVolume) error {
 		if err != nil {
 			err = newExecError(out, err)
 			klog.Errorf(
-				"lvm: could not create snapshot %v cmd %v error: %s", volume, args, string(out),
+				"lvm restore: could not create snapshot %v cmd %v error: %s", volume, args, string(out),
 			)
 			return err
 		}
@@ -364,12 +372,32 @@ func CreateVolume(vol *apis.LVMVolume) error {
 		if err != nil {
 			err = newExecError(out, err)
 			klog.Errorf(
-				"lvm: could not activate volume %v cmd %v error: %s", volume, args, string(out),
+				"lvm restore: could not activate volume %v cmd %v error: %s", volume, args, string(out),
 			)
 			return err
 		}
 
-		klog.Infof("lvm: created restored volume %s from thin snapshot %s as source", volume, snapName)
+		// check volume exists after restore
+		volExists, err := CheckVolumeExists(vol)
+		if err != nil {
+			klog.Errorf("lvm restore: failed to check restored volume %s existence: %v", volume, err)
+			return err
+		}
+		if !volExists {
+			klog.Errorf("lvm restore: volume (%s) doesn't exists", volume)
+			return fmt.Errorf("restored volume %s doesn't exists", volume)
+		}
+
+		// change restored volume filesystem UUID to avoid conflicts
+		err = updateVolumeUuid(vol)
+		if err != nil {
+			klog.Errorf(
+				"lvm restore: failed to update UUID for restored volume %s: %v", volume, err,
+			)
+			return err
+		}
+
+		klog.Infof("lvm restore: created restored volume %s from thin snapshot %s as source", volume, snapName)
 		return nil
 	}
 	args := buildLVMCreateArgs(vol)
@@ -1427,5 +1455,103 @@ func removeVolumeFilesystem(lvmVolume *apis.LVMVolume) error {
 		)
 	}
 	klog.V(4).Infof("Successfully wiped filesystem on device path: %s", devicePath)
+	return nil
+}
+
+// updateVolumeUuid will update volume xfs and btrfs filesyetm UUID
+func updateVolumeUuid(lvmVolume *apis.LVMVolume) error {
+	devicePath := fmt.Sprintf("%s%s/%s", DevPath, lvmVolume.Spec.VolGroup, lvmVolume.Name)
+
+	// get volume filesystem type
+	fsType, err := detectFsType(devicePath)
+	if err != nil {
+		klog.Errorf("failed to detect filesystem type for device %s, error: %v", devicePath, err)
+		return err
+	}
+	klog.Infof("Detected filesystem type %s for device %s", fsType, devicePath)
+	// Skip UUID change for ext4/ext3 or block devices without filesystem
+	if fsType == "ext4" || fsType == "ext3" || fsType == "" {
+		klog.Infof("Skipping UUID update for %s (fs: %s)", devicePath, fsType)
+		return nil
+	}
+
+	// update volume UUID based on filesystem type
+	switch fsType {
+	case "btrfs":
+		err := updateBtrfsUUID(devicePath)
+		if err != nil {
+			klog.Errorf("failed to update device btrfs filesystem %s UUID, error: %v", devicePath, err)
+			return err
+		}
+		klog.Infof("Successfully updated btrfs filesystem UUID for device %s", devicePath)
+	case "xfs":
+		err := updateXfsUUID(devicePath)
+		if err != nil {
+			klog.Errorf("failed to update device xfs filesystem %s UUID, error: %v", devicePath, err)
+			return err
+		}
+		klog.Infof("Successfully updated xfs filesystem UUID for device %s", devicePath)
+	default:
+		klog.Errorf("unsupported filesystem type %s for device %s", fsType, devicePath)
+		return fmt.Errorf("unsupported filesystem type %s for device %s", fsType, devicePath)
+	}
+	return nil
+}
+
+// detectFsType will detect filesystem type for given device path
+func detectFsType(devicePath string) (string, error) {
+	// get only TYPE of the filesystem
+	// Command: blkid -s TYPE -o value /dev/lvmvg/pvc-14e7c929-db3f-4335-b492-485ac6e56454
+	out, _, err := RunCommandSplit(BlockIdCommand, "-s", "TYPE", "-o", "value", devicePath)
+	if err != nil {
+		klog.Errorf("failed to get device %s TYPE, error: %v ,out: %s", devicePath, err, string(out))
+		return "", err
+	}
+	klog.V(4).Infof("Successfully fetched device %s TYPE %s", devicePath, strings.TrimSpace(string(out)))
+	return strings.TrimSpace(string(out)), nil
+}
+
+// updateBtrfsUUID update UUID of btrfs filesystem for given device path
+// command: yes | btrfstune -u /dev/lvmvg/pvc-d16fa9be-806d-4eb2-ae80-fd35e67a3483
+func updateBtrfsUUID(devicePath string) error {
+	cmd := exec.Command(BtrfstuneCommand, "-u", devicePath)
+	// Get stdin pipe to send response
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("failed to get stdin pipe: %w", err)
+	}
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	// Start the command
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("failed to start btrfstune: %w", err)
+	}
+	// Send EXACTLY "y" to stdin to confirm UUID change
+	_, err = stdin.Write([]byte("y"))
+	if err != nil {
+		_ = cmd.Process.Kill()
+		return fmt.Errorf("failed to send 'y': %v", err)
+	}
+	stdin.Close() // Critical: unblocks the process
+	// Wait for completion
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("btrfstune failed: %v\nOutput: %s", err, out.String())
+	}
+	klog.V(4).Infof("Btrfs UUID updated: %s", out.String())
+	return nil
+}
+
+// updateXfsUUID updates the UUID of an XFS filesystem using xfs_admin -U generate
+// command: xfs_admin -U generate: generates and applies a new UUID directly
+func updateXfsUUID(devicePath string) error {
+	cmd := exec.Command(XFSAdminCommand, "-U", "generate", devicePath)
+	// Capture both stdout and stderr
+	output, err := cmd.CombinedOutput()
+	outStr := strings.TrimSpace(string(output))
+	if err != nil {
+		return fmt.Errorf("xfs_admin failed on %s: %w\nOutput: %s", devicePath, err, outStr)
+	}
+	klog.V(4).Infof("XFS UUID updated: %s", outStr)
 	return nil
 }

--- a/pkg/lvm/volume.go
+++ b/pkg/lvm/volume.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	klog "k8s.io/klog/v2"
 
@@ -286,9 +287,16 @@ func UpdateSnapInfo(snap *apis.LVMSnapshot) error {
 	if snap.Finalizers != nil {
 		return nil
 	}
-
+	snapName := getLVMSnapName(snap.Name)
+	snapLvSizeBytes, err := getLVSize(snapName, snap.Spec.VolGroup)
+	if err != nil {
+		klog.Errorf("Failed to get snapshot LV size %s err: %s", snap.Name, err.Error())
+		return err
+	}
+	snapLvSize := *resource.NewQuantity(int64(snapLvSizeBytes), resource.BinarySI)
 	newSnap, err := snapbuilder.BuildFrom(snap).
 		WithFinalizer(finalizers).
+		WithLvSize(snapLvSize).
 		WithLabels(labels).Build()
 
 	newSnap.Status.State = LVMStatusReady

--- a/pkg/mgmt/volume/volume.go
+++ b/pkg/mgmt/volume/volume.go
@@ -194,6 +194,11 @@ func (c *VolController) syncVol(vol *apis.LVMVolume) error {
 		if err == nil {
 			return lvm.UpdateVolInfo(vol, lvm.LVMStatusReady)
 		}
+		klog.Infof("lvm volume %v provisioning failed: %v", vol.Name, err)
+		// In case lvm.CreateVolume fails for given volume group,
+		// mark the volume provisioning failed.
+		vol.Status.Error = c.transformLVMError(err)
+		return lvm.UpdateVolInfo(vol, lvm.LVMStatusFailed)
 	}
 
 	vgs, err := c.getVgPriorityList(vol)


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
This PR create LVM volume restore when thin snapshot is set as source.

**What this PR does?**:
- Update snapshot CR status with LV size
- Creates LVM thin snapshot from source thin snapshot.
- Activate the new thin snapshot.
- Update XFS and btrfs filesyetem UUID for restored volume.
- Update Dockerfile to include `btrfs-progs-extra` package which have `btrfstune` utility . Btrfstune is required to update btrfs filesystem UUID.

**Checklist:**
- [ ] Fixes #<issue number>
- [ ] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
