### PR TITLE
remove node from selected which are not in nmap

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -2,6 +2,7 @@ package driver
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -350,13 +351,21 @@ func CreateLVMVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 		// run the scheduler
 		selected := schd.Scheduler(req, nmap)
 
+		// removes the node from the selected if not present in nmap
+		selected = slices.DeleteFunc(selected, func(s string) bool {
+			_, ok := nmap[s]
+			return !ok
+		})
+
 		if len(selected) == 0 {
 			return nil, status.Error(codes.ResourceExhausted, "scheduler failed, not able to select a node to create the PV")
 		}
 
 		owner = selected[0]
 	}
-
+	klog.Infof("scheduling the volume %s/%s on node %s",
+		params.VgPattern.String(), volName, owner)
+		
 	volObj, err := volbuilder.NewBuilder().
 		WithName(volName).
 		WithCapacity(capacity).


### PR DESCRIPTION
VolumeWeighted and CapacityWeighted schedulers used to ignore nodes which doesn't have any volumes scheduled on them.

Hence in lib-csi, it adds such nodes to the start of the preferred list:

https://github.com/openebs/lib-csi/blob/develop/pkg/scheduler/scheduler.go#L79

Now localpv-lvm, uses node object in CapacityWeighted and VolumeWeighted algorithm. So, it will not ignore any nodes which doesn't have volumes on them.

https://github.com/openebs/lvm-localpv/pull/418/files#diff-5df8dda72c6252053011798747eb39268924c39d7fa13c21884bdada3fde0bfeR51

Also, Now we explicitly ignore nodes for scheduling if it doesn't have VG which can accommodate thick PVC. So we will not consider the nodes which are not in nmap.

