### PR TITLE
fix(lvm): Consistently build volume device paths as /dev/mapper/group--name-volume--name

### DIFF
--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -658,11 +658,8 @@ func checkThinPoolEmpty(poolname string) bool {
 
 // CheckVolumeExists validates if lvm volume exists
 func CheckVolumeExists(vol *apis.LVMVolume) (bool, error) {
-	devPath, err := GetVolumeDevPath(vol)
-	if err != nil {
-		return false, err
-	}
-	if _, err = os.Stat(devPath); err != nil {
+	devPath := GetVolumeDevPath(vol)
+	if _, err := os.Stat(devPath); err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
@@ -672,7 +669,7 @@ func CheckVolumeExists(vol *apis.LVMVolume) (bool, error) {
 }
 
 // GetVolumeDevPath returns devpath for the given volume
-func GetVolumeDevPath(vol *apis.LVMVolume) (string, error) {
+func GetVolumeDevPath(vol *apis.LVMVolume) string {
 	// LVM doubles the hiphen for the mapper device name
 	// and uses single hiphen to separate volume group from volume
 	vg := strings.ReplaceAll(vol.Spec.VolGroup, "-", "--")
@@ -680,7 +677,7 @@ func GetVolumeDevPath(vol *apis.LVMVolume) (string, error) {
 	lv := strings.ReplaceAll(vol.Name, "-", "--")
 	dev := DevMapperPath + vg + "-" + lv
 
-	return dev, nil
+	return dev
 }
 
 // Validate the size volume based on extents. If the number of extents are already

--- a/pkg/lvm/lvm_util.go
+++ b/pkg/lvm/lvm_util.go
@@ -267,7 +267,7 @@ func buildLVMCreateArgs(vol *apis.LVMVolume) []string {
 func buildLVMDestroyArgs(vol *apis.LVMVolume) []string {
 	var LVMVolArg []string
 
-	dev := DevPath + vol.Spec.VolGroup + "/" + vol.Name
+	dev := GetVolumeDevPath(vol)
 
 	LVMVolArg = append(LVMVolArg, "-y", dev)
 
@@ -683,7 +683,7 @@ func GetVolumeDevPath(vol *apis.LVMVolume) string {
 // Validate the size volume based on extents. If the number of extents are already
 // greater than or equal to required, then make a no-op.
 func needsLvResize(vol *apis.LVMVolume, desiredSizeBytes uint64) bool {
-	lvPath := DevPath + vol.Spec.VolGroup + "/" + vol.Name
+	lvPath := GetVolumeDevPath(vol)
 	vgName := vol.Spec.VolGroup
 
 	// 1. Get LV Size in bytes, without the unit suffix.
@@ -733,7 +733,7 @@ func needsLvResize(vol *apis.LVMVolume, desiredSizeBytes uint64) bool {
 func buildVolumeResizeArgs(vol *apis.LVMVolume, resizefs bool) []string {
 	var LVMVolArg []string
 
-	dev := DevPath + vol.Spec.VolGroup + "/" + vol.Name
+	dev := GetVolumeDevPath(vol)
 	size := vol.Spec.Capacity + "b"
 
 	LVMVolArg = append(LVMVolArg, dev, "-L", size)
@@ -1509,7 +1509,7 @@ func getThinPoolSize(vgname, volsize string) string {
 
 // removeVolumeFilesystem will erases the filesystem signature from lvm volume
 func removeVolumeFilesystem(lvmVolume *apis.LVMVolume) error {
-	devicePath := filepath.Join(DevPath, lvmVolume.Spec.VolGroup, lvmVolume.Name)
+	devicePath := GetVolumeDevPath(lvmVolume)
 
 	// wipefs erases the filesystem signature from the lvm volume
 	// -a    wipe all magic strings
@@ -1531,7 +1531,7 @@ func removeVolumeFilesystem(lvmVolume *apis.LVMVolume) error {
 
 // updateVolumeUuid will update volume xfs and btrfs filesyetm UUID
 func updateVolumeUuid(lvmVolume *apis.LVMVolume) error {
-	devicePath := fmt.Sprintf("%s%s/%s", DevPath, lvmVolume.Spec.VolGroup, lvmVolume.Name)
+	devicePath := GetVolumeDevPath(lvmVolume)
 
 	// get volume filesystem type
 	fsType, err := detectFsType(devicePath)

--- a/pkg/lvm/mount.go
+++ b/pkg/lvm/mount.go
@@ -201,7 +201,7 @@ func MountVolume(vol *apis.LVMVolume, mount *MountInfo, podLVInfo *PodLVInfo) er
 		return nil
 	}
 
-	devicePath := DevPath + volume
+	devicePath := GetVolumeDevPath(vol)
 
 	err = FormatAndMountVol(devicePath, mount)
 	if err != nil {
@@ -237,8 +237,7 @@ func MountFilesystem(vol *apis.LVMVolume, mount *MountInfo, podinfo *PodLVInfo) 
 // MountBlock mounts the block disk to the specified path
 func MountBlock(vol *apis.LVMVolume, mountinfo *MountInfo, podLVInfo *PodLVInfo) error {
 	target := mountinfo.MountPath
-	volume := vol.Spec.VolGroup + "/" + vol.Name
-	devicePath := DevPath + volume
+	devicePath := GetVolumeDevPath(vol)
 
 	mountopt := []string{"bind"}
 

--- a/pkg/lvm/mount.go
+++ b/pkg/lvm/mount.go
@@ -154,12 +154,7 @@ func verifyMountRequest(vol *apis.LVMVolume, mountpath string) (bool, error) {
 		return false, status.Error(codes.Internal, "verifyMount: volume is not ready to be mounted")
 	}
 
-	devicePath, err := GetVolumeDevPath(vol)
-	if err != nil {
-		klog.Errorf("can not get device for volume:%s dev %s err: %v",
-			vol.Name, devicePath, err.Error())
-		return false, status.Errorf(codes.Internal, "verifyMount: GetVolumePath failed %s", err.Error())
-	}
+	devicePath := GetVolumeDevPath(vol)
 
 	/*
 	 * This check is the famous *Wall Of North*


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

#432

**What this PR does?**:

It changes how the lvm volume device paths are constructed such that e.g. xfs_growfs correctly works. The paths were inconsistently constructed.

**Does this PR require any upgrade changes?**:

Nope.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

* Not yet.

**Any additional information for your reviewer?** :
_Mention if this PR is part of any design or a continuation of previous PRs_

I haven't tested this at all currently (except `make test`). I intent to build a custom container and test this in a cluster of mine. If there is a good reference for a integration test I could add one, but I'm not convinced I can run the CI test setup locally without breaking stuff around here.


**Checklist:**
- [X] Fixes #432
- [X] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [X] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [X] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them:
