### PR TITLE
fix: update unit test code coverage action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
         if: inputs.coverage
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.txt
           directory: ./coverage
           flags: unittests
           fail_ci_if_error: true


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
Unit test code coverage action is failing with unknown option file in v5 version.

**What this PR does?**:
Replace code coverage action `file` parameter with supported `files` parameter.