### PR TITLE
ci: bump trivy action version

### DIFF
--- a/.github/workflows/trivy-ci.yml
+++ b/.github/workflows/trivy-ci.yml
@@ -37,7 +37,7 @@ jobs:
           '
 
       - name: Trivy Helm misconfiguration scan
-        uses: aquasecurity/trivy-action@0.33.1
+        uses: aquasecurity/trivy-action@0.34.2
         with:
             scan-type: config
             scan-ref: deploy/helm/charts/rendered.yaml


### PR DESCRIPTION

**Why is this PR required? What issue does it fix?**:
The workflows were failing due to https://github.com/aquasecurity/trivy/discussions/10265
This is fixed by using the latest release v.0.34.2.

**What this PR does?**:
Bumps the version of trivy-avction to 0.34.2

**Does this PR require any upgrade changes?**:
No

