### PR TITLE
feat: add helm global values

### DIFF
--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -87,7 +87,12 @@ helm install openebs-lvmlocalpv openebs-lvmlocalpv/lvm-localpv --namespace opene
 
 | Parameter                                           | Description                                                                      | Default                                 |
 |-----------------------------------------------------|----------------------------------------------------------------------------------|-----------------------------------------|
-| `crds.csi.volumeSnapshots.enabled`                  | Enable/Disable installation of VolumeSnapshot-related CRDs                       | `true`                                   |
+| `global.imageRegistry`                              | Global override for container image registry                                                     | `""`                            |
+| `global.imagePullSecrets`                           | Global image pull secrets (merged with local imagePullSecrets and not overridden)                                                  | `[]`                            |
+| `global.imagePullPolicy`                            | Global override for image pull policy                                                       | `""`                            |
+| `global.analytics.enabled`                          | Global override for analytics                                                    | `""`                            |
+| `global.kubeletDir`                                 | Global override for kubelet directory                                                    | `""`                            |
+| `crds.csi.volumeSnapshots.enabled`                  | Enable/Disable installation of VolumeSnapshot-related CRDs                       | `true`                                  |
 | `imagePullSecrets`                                  | Provides image pull secret                                                       | `""`                                    |
 | `lvmPlugin.image.registry`                          | Registry for openebs-lvm-plugin image                                            | `""`                                    |
 | `lvmPlugin.image.repository`                        | Image repository for openebs-lvm-plugin                                          | `openebs/lvm-driver`                    |

--- a/deploy/helm/charts/templates/_helpers.tpl
+++ b/deploy/helm/charts/templates/_helpers.tpl
@@ -141,5 +141,54 @@ Create the name of the priority class for csi controller plugin
 Ensure that the path to kubelet ends with a slash
 */}}
 {{- define "lvmlocalpv.lvmNode.kubeletDir" -}}
-{{- printf "%s/" (.Values.lvmNode.kubeletDir | trimSuffix "/") -}}
+{{- printf "%s/" (default .Values.lvmNode.kubeletDir .Values.global.kubeletDir | trimSuffix "/") -}}
 {{- end }}
+
+{{/*
+Creates the image URL ie registry/repository:tag
+*/}}
+{{- define "lvmlocalpv.common.image" -}}
+{{- $registryName := default .imageRoot.registry ((.global).imageRegistry) | trimSuffix "/" -}}
+{{- $repositoryName := .imageRoot.repository -}}
+{{- $termination := .imageRoot.tag | toString -}}
+{{- if $registryName }}
+    {{- printf "%s/%s:%s" $registryName $repositoryName $termination -}}
+{{- else -}}
+    {{- printf "%s:%s"  $repositoryName $termination -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Concatenates imagepullsecrets and handles different formats (example - secret or - name: secret)
+*/}}
+{{- define "lvmlocalpv.common.pullSecrets" -}}
+{{- $names := list -}}
+{{- with .Values.global.imagePullSecrets -}}
+  {{- range . -}}
+    {{- if kindIs "map" . }}
+      {{- if and (hasKey . "name") (not (empty .name)) -}}
+        {{ $names = append $names .name }}
+      {{- end -}}
+    {{- else if not (empty .) -}}
+      {{ $names = append $names . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- with .Values.imagePullSecrets -}}
+  {{- range . }}
+    {{- if kindIs "map" . -}}
+      {{- if and (hasKey . "name") (not (empty .name)) -}}
+        {{- $names = append $names .name }}
+      {{- end -}}
+    {{- else if not (empty .) -}}
+     {{- $names = append $names . -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $names = uniq $names -}}
+{{- if $names -}}
+{{- range $names }}
+- name: {{ . }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/charts/templates/lvm-controller.yaml
+++ b/deploy/helm/charts/templates/lvm-controller.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.lvmController.name }}
       containers:
         - name: {{ .Values.lvmController.resizer.name }}
-          image: "{{ .Values.lvmController.resizer.image.registry }}{{ .Values.lvmController.resizer.image.repository }}:{{ .Values.lvmController.resizer.image.tag }}"
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.resizer.image "global" .Values.global) }}
           args:
             - "--v={{ .Values.lvmController.logLevel }}"
             - "--csi-address=$(ADDRESS)"
@@ -49,15 +49,15 @@ spec:
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: {{ .Values.lvmController.resizer.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.lvmController.resizer.image.pullPolicy .Values.global.imagePullPolicy }}
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
         - name: {{ .Values.lvmController.snapshotter.name }}
-          image: "{{ .Values.lvmController.snapshotter.image.registry }}{{ .Values.lvmController.snapshotter.image.repository }}:{{ .Values.lvmController.snapshotter.image.tag }}"
-          imagePullPolicy: {{ .Values.lvmController.snapshotter.image.pullPolicy }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotter.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.lvmController.snapshotter.image.pullPolicy .Values.global.imagePullPolicy}}
           args:
             - "--csi-address=$(ADDRESS)"
             {{- if gt (int .Values.lvmController.replicas) 1 }}
@@ -72,18 +72,18 @@ spec:
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
         - name: {{ .Values.lvmController.snapshotController.name }}
-          image: "{{ .Values.lvmController.snapshotController.image.registry }}{{ .Values.lvmController.snapshotController.image.repository }}:{{ .Values.lvmController.snapshotController.image.tag }}"
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotController.image "global" .Values.global) }}
           args:
             - "--v={{ .Values.lvmController.logLevel }}"
             {{- if gt (int .Values.lvmController.replicas) 1 }}
             - "--leader-election=true"
             {{- end }}
-          imagePullPolicy: {{ .Values.lvmController.snapshotController.image.pullPolicy }}
+          imagePullPolicy: {{ default .Values.lvmController.snapshotController.image.pullPolicy .Values.global.imagePullPolicy }}
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
         - name: {{ .Values.lvmController.provisioner.name }}
-          image: "{{ .Values.lvmController.provisioner.image.registry }}{{ .Values.lvmController.provisioner.image.repository }}:{{ .Values.lvmController.provisioner.image.tag }}"
-          imagePullPolicy: {{ .Values.lvmController.provisioner.image.pullPolicy }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.provisioner.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.lvmController.provisioner.image.pullPolicy .Values.global.imagePullPolicy}}
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v={{ .Values.lvmController.logLevel }}"
@@ -112,8 +112,8 @@ spec:
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
         - name: {{ .Values.lvmPlugin.name }}
-          image: "{{ .Values.lvmPlugin.image.registry }}{{ .Values.lvmPlugin.image.repository }}:{{ .Values.lvmPlugin.image.tag }}"
-          imagePullPolicy: {{ .Values.lvmPlugin.image.pullPolicy }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmPlugin.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.lvmPlugin.image.pullPolicy .Values.global.imagePullPolicy }}
           env:
             - name: OPENEBS_CONTROLLER_DRIVER
               value: controller
@@ -126,7 +126,11 @@ spec:
             - name: OPENEBS_IO_INSTALLER_TYPE
               value: "lvm-localpv-helm"
             - name: OPENEBS_IO_ENABLE_ANALYTICS
+              {{- if kindIs "bool" .Values.global.analytics.enabled }}
+              value: "{{ .Values.global.analytics.enabled }}"
+              {{- else}}
               value: "{{ .Values.analytics.enabled }}"
+              {{- end}}
             {{- if .Values.analytics.gaId }}
             - name: GA_ID
               value: {{ .Values.analytics.gaId | quote }}
@@ -148,10 +152,10 @@ spec:
       volumes:
         - name: socket-dir
           emptyDir: {}
-{{- if .Values.imagePullSecrets }}
+      {{- if or .Values.global.imagePullSecrets .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-{{- end }}
+      {{- include "lvmlocalpv.common.pullSecrets" . | indent 6 }}
+      {{- end }}
 {{- if .Values.lvmController.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.lvmController.nodeSelector | indent 8 }}

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -36,8 +36,8 @@ spec:
       hostNetwork: {{ .Values.lvmNode.hostNetwork }}
       containers:
         - name: {{ .Values.lvmNode.driverRegistrar.name }}
-          image: "{{ .Values.lvmNode.driverRegistrar.image.registry }}{{ .Values.lvmNode.driverRegistrar.image.repository }}:{{ .Values.lvmNode.driverRegistrar.image.tag }}"
-          imagePullPolicy: {{ .Values.lvmNode.driverRegistrar.image.pullPolicy }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmNode.driverRegistrar.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.lvmNode.driverRegistrar.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "--v={{ .Values.lvmNode.logLevel }}"
             - "--csi-address=$(ADDRESS)"
@@ -68,8 +68,8 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: "{{ .Values.lvmPlugin.image.registry }}{{ .Values.lvmPlugin.image.repository }}:{{ .Values.lvmPlugin.image.tag }}"
-          imagePullPolicy: {{ .Values.lvmPlugin.image.pullPolicy }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmPlugin.image "global" .Values.global) }}
+          imagePullPolicy: {{ default .Values.lvmPlugin.image.pullPolicy .Values.global.imagePullPolicy}}
           args:
             - "--nodeid=$(OPENEBS_NODE_ID)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
@@ -146,10 +146,10 @@ spec:
           hostPath:
             path: {{ include "lvmlocalpv.lvmNode.kubeletDir" . | quote }}
             type: Directory
-{{- if .Values.imagePullSecrets }}
+      {{- if or .Values.global.imagePullSecrets .Values.imagePullSecrets }}
       imagePullSecrets:
-{{ toYaml .Values.imagePullSecrets | indent 8 }}
-{{- end }}
+      {{- include "lvmlocalpv.common.pullSecrets" . | indent 6 }}
+      {{- end }}
 {{- if .Values.lvmNode.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.lvmNode.nodeSelector | indent 8 }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -2,8 +2,25 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  # Global override for container image registry.
+  imageRegistry: ""
+  # Global image pull secrets (merged with local imagePullSecrets and not overridden)
+  # - secret
+  imagePullSecrets: []
+  # # Global override for image pull policy
+  imagePullPolicy: ""
+  analytics:
+    # Global override for analytics
+    enabled:
+  # Global override for kubelet directory
+  # This can be configured to run on various different k8s distributions like
+  # microk8s where kubelet dir is different
+  kubeletDir: ""
+
+# - secret
 imagePullSecrets:
-# - name: "image-pull-secret"
+
 
 # enable storage capacity tracking feature
 # Ref: https://kubernetes:io/docs/concepts/storage/storage-capacity


### PR DESCRIPTION
## Why is this PR required? What issue does it fix?

Currently, the Helm charts do not provide global variables for configuring common parameters such as the image registry, image pull secrets, image pull policy, and analytics settings.

When deploying the OpenEBS Helm charts, users often need to override these values across multiple subcharts and components. This makes it difficult to locate and configure all the required fields consistently. Providing global variables simplifies configuration and improves the user experience.

## What does this PR do?

This PR introduces the following global configuration variables:
```yaml
global:
  # Global override for container image registry.
  imageRegistry: ""
  # - secret
  imagePullSecrets: []
  # # Global overide for image pull policy
  imagePullPolicy: ""
  analytics:
    # Global overide for analytics
    enabled:
```

These variables allow users to configure common settings in a single place, which will then be applied across the chart components.

## Does this PR require any upgrade changes?

No.
This change is backward compatible and does not require any upgrade steps.

## Verification

The changes were verified using the following scenarios:

Rendered the templates using helm template to confirm correct value substitution.

Deployed the chart on a Kubernetes cluster with 3 worker nodes (kubeadm-based setup).

Verified that the global values are rendered and applied correctly across the components.