### PR TITLE
fix(controller): fallback to VG capacity if thin pool is missing

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -971,22 +971,12 @@ func (cs *controller) GetCapacity(
 			vgThinPoolName := fmt.Sprintf("%s_thinpool", vg.Name)
 			freeCapacity := vg.Free.Value()
 			if params.ThinProvision == lvm.YES {
-				foundPool := false
 				for _, pool := range vg.ThinPools {
 					if pool.Name == vgThinPoolName {
 						freeCapacity += pool.Free.Value()
-						foundPool = true
 						break
 					}
 				}
-				// If thin pool isn't found, report VG free capacity
-				// because the driver will create the pool automatically.
-				if !foundPool {
-					klog.V(4).Infof("Thin pool %s not found on node %s, falling back to VG free capacity: %d",
-						vgThinPoolName, nodeName, vg.Free.Value())
-				}
-			} else {
-				freeCapacity = vg.Free.Value()
 			}
 			if availableCapacity < freeCapacity {
 				availableCapacity = freeCapacity

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -968,14 +968,22 @@ func (cs *controller) GetCapacity(
 			if !params.VgPattern.MatchString(vg.Name) {
 				continue
 			}
-
-			var freeCapacity int64
+			vgThinPoolName := fmt.Sprintf("%s_thinpool", vg.Name)
+			freeCapacity := vg.Free.Value()
 			if params.ThinProvision == lvm.YES {
+				foundPool := false
 				for _, pool := range vg.ThinPools {
-					if pool.Name == vg.Name+"_thinpool" {
-						freeCapacity = pool.Free.Value()
+					if pool.Name == vgThinPoolName {
+						freeCapacity += pool.Free.Value()
+						foundPool = true
 						break
 					}
+				}
+				// If thin pool isn't found, report VG free capacity
+				// because the driver will create the pool automatically.
+				if !foundPool {
+					klog.V(4).Infof("Thin pool %s not found on node %s, falling back to VG free capacity: %d",
+						vgThinPoolName, nodeName, vg.Free.Value())
 				}
 			} else {
 				freeCapacity = vg.Free.Value()

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
+	storagev1 "k8s.io/api/storage/v1"
 )
 
 var _ = Describe("[lvmpv] TEST VOLUME PROVISIONING", func() {
@@ -236,7 +237,8 @@ func sharedVolumeTest() {
 }
 
 func thinVolCreationTest() {
-	By("Creating thinProvision storage class", createThinStorageClass)
+	By("Creating thinProvision storage class")
+	createThinStorageClass(storagev1.VolumeBindingImmediate)
 	By("creating and verifying PVC bound status")
 	createAndVerifyPVC(true)
 	By("Creating and deploying app pod")
@@ -259,8 +261,27 @@ func thinVolCreationTest() {
 	By("Deleting thinProvision storage class", deleteStorageClass)
 }
 
+func thinVolCreationLateBindingTest() {
+	By("Creating thinProvision storage class")
+	createThinStorageClass(storagev1.VolumeBindingWaitForFirstConsumer)
+	By("creating and verifying PVC bound status")
+	createAndVerifyPVC(false)
+	By("Creating and deploying app pod")
+	createDeployVerifyApp(appNames, pvcObj)
+	By("Verifying that PV is created after mount")
+	verifyPVForPVC(true, pvcName)
+	By("Verifying LVMVolume object to be Ready")
+	VerifyLVMVolume(true, "", pvcObj)
+	By("Deleting pvc/pod")
+	deleteAppAndPvc(appNames, pvcName)
+	By("Verifying that PV is deleted after deletion")
+	verifyPVForPVC(false, pvcName)
+	By("Deleting storage class", deleteStorageClass)
+}
+
 func thinVolCapacityTest() {
-	By("Creating thinProvision storage class", createThinStorageClass)
+	By("Creating thinProvision storage class")
+	createThinStorageClass(storagev1.VolumeBindingImmediate)
 	By("creating and verifying PVC bound status")
 	createAndVerifyPVC(true)
 	By("enabling monitoring on thinpool", enableThinpoolMonitoring)
@@ -348,6 +369,7 @@ func volumeCreationTest() {
 	By("###Running filesystem with formatOptions creation test###", formatOptionsTest)
 	By("###Running block volume creation test###", blockVolCreationTest)
 	By("###Running thin volume creation test###", thinVolCreationTest)
+	By("###Running thin volume creation with late binding test###", thinVolCreationLateBindingTest)
 	By("###Running leak protection test###", leakProtectionTest)
 	By("###Running shared volume for two app pods on same node test###", sharedVolumeTest)
 }
@@ -355,7 +377,8 @@ func volumeCreationTest() {
 func volumeDeletionTest() {
 	device := setupVg(40, "lvmvg")
 	defer cleanupVg(device, "lvmvg")
-	By("Creating thinProvision storage class", createThinStorageClass)
+	By("Creating thinProvision storage class")
+	createThinStorageClass(storagev1.VolumeBindingImmediate)
 	By("Creating and verifying a PVC bound status")
 	createAndVerifyBlockPVCId(true, "1")
 	By("Verifying LVMVolume object to be Ready")
@@ -388,7 +411,8 @@ func capacityTest() {
 func thinSnapshotRestoreToNewThinVolume() {
 	device := setupVg(40, "lvmvg")
 	defer cleanupVg(device, "lvmvg")
-	By("Creating thinProvision storage class", createThinStorageClass)
+	By("Creating thinProvision storage class")
+	createThinStorageClass(storagev1.VolumeBindingImmediate)
 	By("creating and verifying PVC bound status")
 	createAndVerifyPVC(true)
 	By("Creating and deploying app pod")

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -11,6 +11,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -210,7 +211,7 @@ func createSharedVolStorageClass() {
 	gomega.Expect(err).To(gomega.BeNil(), "while creating a shared volume storageclass {%s}", scName)
 }
 
-func createThinStorageClass() {
+func createThinStorageClass(bindingMode storagev1.VolumeBindingMode) {
 	var (
 		err error
 	)
@@ -225,7 +226,9 @@ func createThinStorageClass() {
 		WithGenerateName(scName).
 		WithParametersNew(parameters).
 		WithVolumeExpansion(true).
-		WithProvisioner(LocalProvisioner).Build()
+		WithProvisioner(LocalProvisioner).
+		WithVolumeBindingMode(bindingMode).
+		Build()
 	gomega.Expect(err).ShouldNot(gomega.HaveOccurred(),
 		"while building thinProvision storageclass obj with prefix {%s}", scName)
 
@@ -816,6 +819,8 @@ func verifyPVForPVC(shouldExist bool, pvcName string) {
 	}
 
 	gomega.Expect(matchingPVExists).To(shouldPVExist)
+	ginkgo.By("Update pvc object")
+	pvcObj, err = PVCClient.WithNamespace(OpenEBSNamespace).Get(pvcObj.Name, metav1.GetOptions{})
 }
 
 // IsPVDeletedEventually checks if the PV is deleted or not eventually


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
When `thinProvision` is enabled and the StorageClass uses `volumeBindingMode: WaitForFirstConsumer`, the `GetCapacity` call returns `0` if the expected thin pool does not already exist on the node. However, because the scheduler sees `0` capacity during the scheduling cycle, it never selects a node, and `CreateVolume` is never triggered. This creates a deadlock for new thin-provisioned volumes.

**What this PR does?**:
Modified `GetCapacity` to report the Volume Group's free capacity as a fallback if the thin pool is not found. This allows the scheduler to bind the volume to a viable node, subsequently triggering the `CreateVolume` call where the thin pool will be automatically provisioned.

**Does this PR require any upgrade changes?**:
No