### PR TITLE
fix(resize): keep node expansion required for idempotent expand

### DIFF
--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -671,6 +671,7 @@ func (cs *controller) ControllerExpandVolume(
 	if volsize >= updatedSize {
 		return csipayload.NewControllerExpandVolumeResponseBuilder().
 			WithCapacityBytes(volsize).
+			WithNodeExpansionRequired(true).
 			Build(), nil
 	}
 


### PR DESCRIPTION
Fixes #316.

This PR fixes an LVM LocalPV resize consistency issue where the controller can return success without preserving node expansion on the idempotent `ControllerExpandVolume` path.

The problematic flow is:

1. `external-resizer` calls `ControllerExpandVolume`.
2. The controller updates `LVMVolume.spec.capacity` to the requested size.
3. The PVC status/condition patch can fail due to a `resourceVersion` conflict.
4. On retry, the controller sees `LVMVolume.spec.capacity >= requestedSize` and returns success from the idempotent path.
5. If that success response does not set `NodeExpansionRequired=true`, kubelet may not call `NodeExpandVolume`, so the actual LV can remain smaller than the requested PVC/LVMVolume size.

This change makes the idempotent success response keep `NodeExpansionRequired=true`.

The actual LV resize is still handled by the existing `NodeExpandVolume` path on the owner node. This keeps the fix scoped to the missing controller response flag, as discussed in the PR review.
