### PR TITLE
fix: imageurl rendered without quotes

### DIFF
--- a/deploy/helm/charts/templates/lvm-controller.yaml
+++ b/deploy/helm/charts/templates/lvm-controller.yaml
@@ -39,7 +39,7 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount.lvmController.name }}
       containers:
         - name: {{ .Values.lvmController.resizer.name }}
-          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.resizer.image "global" .Values.global) }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.resizer.image "global" .Values.global) | quote }}
           args:
             - "--v={{ .Values.lvmController.logLevel }}"
             - "--csi-address=$(ADDRESS)"
@@ -56,7 +56,7 @@ spec:
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
         - name: {{ .Values.lvmController.snapshotter.name }}
-          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotter.image "global" .Values.global) }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotter.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ default .Values.lvmController.snapshotter.image.pullPolicy .Values.global.imagePullPolicy}}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -72,7 +72,7 @@ spec:
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
         - name: {{ .Values.lvmController.snapshotController.name }}
-          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotController.image "global" .Values.global) }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotController.image "global" .Values.global) | quote }}
           args:
             - "--v={{ .Values.lvmController.logLevel }}"
             {{- if gt (int .Values.lvmController.replicas) 1 }}
@@ -82,7 +82,7 @@ spec:
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
         - name: {{ .Values.lvmController.provisioner.name }}
-          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.provisioner.image "global" .Values.global) }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.provisioner.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ default .Values.lvmController.provisioner.image.pullPolicy .Values.global.imagePullPolicy}}
           args:
             - "--csi-address=$(ADDRESS)"
@@ -112,7 +112,7 @@ spec:
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
         - name: {{ .Values.lvmPlugin.name }}
-          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmPlugin.image "global" .Values.global) }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmPlugin.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ default .Values.lvmPlugin.image.pullPolicy .Values.global.imagePullPolicy }}
           env:
             - name: OPENEBS_CONTROLLER_DRIVER

--- a/deploy/helm/charts/templates/lvm-node.yaml
+++ b/deploy/helm/charts/templates/lvm-node.yaml
@@ -36,7 +36,7 @@ spec:
       hostNetwork: {{ .Values.lvmNode.hostNetwork }}
       containers:
         - name: {{ .Values.lvmNode.driverRegistrar.name }}
-          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmNode.driverRegistrar.image "global" .Values.global) }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmNode.driverRegistrar.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ default .Values.lvmNode.driverRegistrar.image.pullPolicy .Values.global.imagePullPolicy }}
           args:
             - "--v={{ .Values.lvmNode.logLevel }}"
@@ -68,7 +68,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmPlugin.image "global" .Values.global) }}
+          image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmPlugin.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ default .Values.lvmPlugin.image.pullPolicy .Values.global.imagePullPolicy}}
           args:
             - "--nodeid=$(OPENEBS_NODE_ID)"


### PR DESCRIPTION
This PR fixes the issue>>
``When a registry value contains YAML-special characters (e.g. {, }, [, ], :, etc.), the rendered YAML is invalid because the parser interprets those characters as flow indicators rather than literal string content.``