### PR TITLE
fail CreateVolume api if both vgPattern and volGroup is passed

### DIFF
--- a/docs/storageclasses.md
+++ b/docs/storageclasses.md
@@ -221,8 +221,6 @@ LocalPV-LVM storageclass supports various parameters for different use cases. Fo
     vgpattern: "lvmvg.*"     ## vgpattern specifies pattern of lvm volume group name
   ```
 
-  if `volgroup` and `vgpattern` both the paramaters are defined in the storageclass then `volgroup` will get higher priority and the driver will use that to provision to the volume.
-
   **Note:** Please note that either volgroup or vgpattern should be present in the storageclass parameters to make the provisioning successful.
 
 - #### volgroup (*must* parameter if vgpattern is not provided, otherwise optional)

--- a/pkg/driver/params.go
+++ b/pkg/driver/params.go
@@ -103,12 +103,19 @@ func NewVolumeParams(m map[string]string) (*VolumeParams, error) {
 	// to the lower case.
 	m = helpers.GetCaseInsensitiveMap(&m)
 
-	// for ensuring backward compatibility, we first check if
-	// there is any volgroup param exists for storage class.
+	vgPattern, vgPatternOK := m["vgpattern"]
+	volGroup, volGroupOK := m["volgroup"]
+	// volgroup and vgpattern are mutually exclusive: volgroup pins the volume
+	// to a single volume group, whereas vgpattern selects among many. Supplying
+	// both is ambiguous, so reject the request.
+	if vgPatternOK && volGroupOK {
+		return nil, status.Errorf(codes.InvalidArgument,
+			"only one of volgroup or vgpattern may be set, but both were provided")
+	}
 
-	vgPattern := m["vgpattern"]
-	volGroup, ok := m["volgroup"]
-	if ok {
+	// for ensuring backward compatibility, if volgroup is provided we derive an
+	// exact-match vgpattern from it.
+	if volGroupOK {
 		vgPattern = fmt.Sprintf("^%v$", volGroup)
 	}
 


### PR DESCRIPTION
 volgroup and vgpattern are mutually exclusive: volgroup pins the volume to a single volume group, whereas vgpattern selects among many. 
Supplying both is ambiguous, so reject the request.