### PR TITLE
feat(helm): allow disabling the snapshot-controller

### DIFF
--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -122,6 +122,7 @@ helm install openebs-lvmlocalpv openebs-lvmlocalpv/lvm-localpv --namespace opene
 | `lvmController.snapshotter.image.repository`        | Image repository for csi-snapshotter                                             | `sig-storage/csi-snapshotter`           |
 | `lvmController.snapshotter.image.pullPolicy`        | Image pull policy for csi-snapshotter                                            | `IfNotPresent`                          |
 | `lvmController.snapshotter.image.tag`               | Image tag for csi-snapshotter                                                    | `v8.2.0`                                |
+| `lvmController.snapshotController.enabled`          | Enable the snapshot-controller container. Disable if the cluster already runs one | `true`                                  |
 | `lvmController.snapshotController.image.registry`   | Registry for snapshot-controller image                                           | `registry.k8s.io/`                      |
 | `lvmController.snapshotController.image.repository` | Image repository for snapshot-controller                                         | `sig-storage/snapshot-controller`       |
 | `lvmController.snapshotController.image.pullPolicy` | Image pull policy for snapshot-controller                                        | `IfNotPresent`                          |

--- a/deploy/helm/charts/templates/lvm-controller.yaml
+++ b/deploy/helm/charts/templates/lvm-controller.yaml
@@ -71,6 +71,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
+        {{- if .Values.lvmController.snapshotController.enabled }}
         - name: {{ .Values.lvmController.snapshotController.name }}
           image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotController.image "global" .Values.global) | quote }}
           args:
@@ -81,6 +82,7 @@ spec:
           imagePullPolicy: {{ default .Values.lvmController.snapshotController.image.pullPolicy .Values.global.imagePullPolicy }}
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
+        {{- end }}
         - name: {{ .Values.lvmController.provisioner.name }}
           image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.provisioner.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ default .Values.lvmController.provisioner.image.pullPolicy .Values.global.imagePullPolicy}}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -114,6 +114,8 @@ lvmController:
       # Overrides the image tag whose default is the chart appVersion.
       tag: v8.2.0
   snapshotController:
+    # There should only be one snapshot-controller per cluster. Set this to false if the cluster already runs one.
+    enabled: true
     name: "snapshot-controller"
     image:
       # Make sure that registry name end with a '/'.


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:
There should only be 1 snapshot-controller running in a cluster as it manages the volumeSnapshot CRDs and it is common for a k8s distribution to ship with a deployment or manage it separately.

**What this PR does?**:
 Allows disabling the snapshot-controller sidecar via the chart.

**Does this PR require any upgrade changes?**:
No

**If the changes in this PR are manually verified, list down the scenarios covered:**:
```
anthony@mac-mini ~/lvm-localpv (feat/optional-snapshot-controller)> helm template openebs deploy/helm/charts -s templates/lvm-controller.yaml --set lvmController.snapshotController.enabled=false | grep snapshot-controller
anthony@mac-mini ~/lvm-localpv (feat/optional-snapshot-controller) [0|1]> helm template openebs deploy/helm/charts -s templates/lvm-controller.yaml | grep snapshot-controller
        - name: snapshot-controller
          image: "registry.k8s.io/sig-storage/snapshot-controller:v8.2.0"
```
**Any additional information for your reviewer?** :
Copy of https://github.com/openebs/zfs-localpv/pull/742 and https://github.com/openebs/mayastor-extensions/pull/971

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [ ] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: