### PR TITLE
fix(ci): remove hard-coded HOME from Nix setup action

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -42,7 +42,6 @@ runs:
           keep-env-derivations = true
           keep-outputs = true
       env:
-        HOME: /home/runner
         NIX_PATH: "${{ steps.nixpkgs.outputs.nix_path }}"
     - name: PreFetch Nix
       if: ${{ inputs.preFetchNix }}


### PR DESCRIPTION
The HOME override breaks on runners where the actual user doesn't match the hard-coded path. Removing it lets the OS provide the correct value for both GitHub-hosted and self-hosted runners.