### PR TITLE
feat(helm): allow disabling the csi-snapshotter

### DIFF
--- a/deploy/helm/charts/README.md
+++ b/deploy/helm/charts/README.md
@@ -119,6 +119,7 @@ helm install openebs-lvmlocalpv openebs-lvmlocalpv/lvm-localpv --namespace opene
 | `lvmController.resizer.image.repository`            | Image repository for csi-resizer                                                 | `sig-storage/csi-resizer`               |
 | `lvmController.resizer.image.pullPolicy`            | Image pull policy for csi-resizer                                                | `IfNotPresent`                          |
 | `lvmController.resizer.image.tag`                   | Image tag for csi-resizer                                                        | `v2.0.0`                                |
+| `lvmController.snapshotter.enabled`                 | Enable the csi-snapshotter container. Disable if VolumeSnapshot CRDs are absent   | `true`                                  |
 | `lvmController.snapshotter.image.registry`          | Registry for csi-snapshotter image                                               | `registry.k8s.io/`                      |
 | `lvmController.snapshotter.image.repository`        | Image repository for csi-snapshotter                                             | `sig-storage/csi-snapshotter`           |
 | `lvmController.snapshotter.image.pullPolicy`        | Image pull policy for csi-snapshotter                                            | `IfNotPresent`                          |

--- a/deploy/helm/charts/templates/lvm-controller.yaml
+++ b/deploy/helm/charts/templates/lvm-controller.yaml
@@ -55,6 +55,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
+        {{- if .Values.lvmController.snapshotter.enabled }}
         - name: {{ .Values.lvmController.snapshotter.name }}
           image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotter.image "global" .Values.global) | quote }}
           imagePullPolicy: {{ default .Values.lvmController.snapshotter.image.pullPolicy .Values.global.imagePullPolicy}}
@@ -71,6 +72,7 @@ spec:
               mountPath: /var/lib/csi/sockets/pluginproxy/
           resources:
             {{- toYaml .Values.lvmController.resources | nindent 12 }}
+        {{- end }}
         {{- if .Values.lvmController.snapshotController.enabled }}
         - name: {{ .Values.lvmController.snapshotController.name }}
           image: {{ include "lvmlocalpv.common.image" (dict "imageRoot" .Values.lvmController.snapshotController.image "global" .Values.global) | quote }}

--- a/deploy/helm/charts/values.yaml
+++ b/deploy/helm/charts/values.yaml
@@ -118,6 +118,8 @@ lvmController:
       # Overrides the image tag whose default is the chart appVersion.
       tag: v2.0.0
   snapshotter:
+    # The csi-snapshotter requires the VolumeSnapshot CRDs. Set this to false if they are not installed.
+    enabled: true
     name: "csi-snapshotter"
     image:
       # Make sure that registry name end with a '/'.


### PR DESCRIPTION
**Why is this PR required? What issue does it fix?**:

The chart supports declining the VolumeSnapshot CRDs via `crds.csi.volumeSnapshots.enabled=false`, but renders the `csi-snapshotter` sidecar unconditionally. Those two settings contradict each other: with the CRDs absent, the sidecar's informer can never list its resource and retries for the life of the pod, roughly once every 30s.

```
E0828 15:31:33.896953 1 reflector.go:227] "Failed to watch" err="failed to list *v1.VolumeSnapshotContent: the server could not find the requested resource (get volumesnapshotcontents.snapshot.storage.k8s.io)" logger="UnhandledError" reflector="github.com/kubernetes-csi/external-snapshotter/client/v8/informers/externalversions/factory.go:143" type="*v1.VolumeSnapshotContent"
```

`lvmController.snapshotController.enabled` (added in #495) guards the `snapshot controller` container a few lines below in the same template, but the `csi-snapshotter` sidecar has no equivalent.

**What this PR does?**:

Adds `lvmController.snapshotter.enabled`, mirroring the `snapshotController.enabled` guard from #495.
Defaults to `true`, so existing installs render unchanged.

The flag is independent of `crds.csi.volumeSnapshots.enabled` on purpose: a cluster can have the CRDs and a shared snapshot-controller managed outside this chart.

**Does this PR require any upgrade changes?**:

No. `enabled: true` is the default; the rendered output is identical unless the flag is explicitly set.

**If the changes in this PR are manually verified, list down the scenarios covered:**:

```
$ helm template openebs deploy/helm/charts -s templates/lvm-controller.yaml --set lvmController.snapshotter.enabled=false | grep csi-snapshotter
$ helm template openebs deploy/helm/charts -s templates/lvm-controller.yaml | grep csi-snapshotter
        - name: csi-snapshotter
          image: "registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0"
```

Full container list, confirming only the one container is affected and the rest keep their order:

```
enabled=true    [csi-resizer, csi-snapshotter, snapshot-controller, csi-provisioner, openebs-lvm-plugin]
enabled=false   [csi-resizer, snapshot-controller, csi-provisioner, openebs-lvm-plugin]
```

Also checked `snapshotter.enabled=false` together with `snapshotController.enabled=false`
(both containers gone, guards nest correctly) and with `replicas=2` (the `--leader-election` branch). `helm lint` passes.

**Any additional information for your reviewer?** :

Same change as #495, one container over.
The counterpart in `zfs-localpv` has the identical gap (`zfsController.snapshotController.enabled` is guarded, `zfsController.snapshotter` is not, as of 2.12.0-develop) so this likely wants the same port that #495 got from zfs-localpv#742. Happy to open that one too if you want them paired.

**Checklist:**
- [ ] Fixes #<issue number>
- [x] PR Title follows the convention of  `<type>(<scope>): <subject>`
- [x] Has the change log section been updated?
- [ ] Commit has unit tests
- [ ] Commit has integration tests
- [ ] (Optional) Are upgrade changes included in this PR? If not, mention the issue/PR to track:
- [ ] (Optional) If documentation changes are required, which issue on https://github.com/openebs/openebs-docs is used to track them: